### PR TITLE
Misc changes that were being upstreamed before we migrated to git

### DIFF
--- a/doc/user-guide/commands.xml
+++ b/doc/user-guide/commands.xml
@@ -887,7 +887,13 @@
 	<bitlbee-setting name="display_name" type="string" scope="account">
 		<description>
 			<para>
-				Currently only available for MSN connections. This setting allows you to read and change your "friendly name" for this connection. Since this is a server-side setting, it can't be changed when the account is off-line.
+				Currently only available for MSN connections, and for jabber groupchats.
+			</para>
+			<para>
+				For MSN: This setting allows you to read and change your "friendly name" for this connection. Since this is a server-side setting, it can't be changed when the account is off-line.
+			</para>
+			<para>
+				For jabber groupchats: this sets the default value of 'nick' for newly created groupchats. There is no way to set an account-wide nick like MSN.
 			</para>
 		</description>
 	</bitlbee-setting>

--- a/protocols/account.c
+++ b/protocols/account.c
@@ -28,7 +28,7 @@
 #include "account.h"
 
 static const char* account_protocols_local[] = {
-	"gg", NULL
+	"gg", "whatsapp", NULL
 };
 
 static char *set_eval_nick_source( set_t *set, char *value );
@@ -350,9 +350,6 @@ static gboolean account_on_timeout( gpointer d, gint fd, b_input_condition cond 
 
 void account_on( bee_t *bee, account_t *a )
 {
-	GHashTableIter nicks;
-	gpointer k, v;
-
 	if( a->ic )
 	{
 		/* Trying to enable an already-enabled account */
@@ -366,15 +363,6 @@ void account_on( bee_t *bee, account_t *a )
 	
 	if( a->ic && !( a->ic->flags & ( OPT_SLOW_LOGIN | OPT_LOGGED_IN ) ) )
 		a->ic->keepalive = b_timeout_add( 120000, account_on_timeout, a->ic );
-
-	if( a->flags & ACC_FLAG_LOCAL )
-	{
-		g_hash_table_iter_init(&nicks, a->nicks);
-		while( g_hash_table_iter_next( &nicks, &k, &v ) )
-		{
-			a->prpl->add_buddy( a->ic, (char*) k, NULL );
-		}
-	}
 }
 
 void account_off( bee_t *bee, account_t *a )

--- a/protocols/jabber/iq.c
+++ b/protocols/jabber/iq.c
@@ -357,10 +357,6 @@ xt_status jabber_pkt_bind_sess( struct im_connection *ic, struct xt_node *node, 
 			if( s )
 				*s = '\0';
 			jabber_set_me( ic, c->text );
-			imcb_log( ic, "Server claims your JID is `%s' instead of `%s'. "
-			          "This mismatch may cause problems with groupchats "
-			          "and possibly other things.",
-			          c->text, ic->acc->user );
 			if( s )
 				*s = '/';
 		}

--- a/protocols/jabber/jabber.c
+++ b/protocols/jabber/jabber.c
@@ -317,6 +317,7 @@ static void jabber_logout( struct im_connection *ic )
 	
 	g_free( jd->oauth2_access_token );
 	g_free( jd->away_message );
+	g_free( jd->internal_jid );
 	g_free( jd->username );
 	g_free( jd->me );
 	g_free( jd );
@@ -620,6 +621,13 @@ void *jabber_buddy_action( struct bee_user *bu, const char *action, char * const
 	return NULL;
 }
 
+gboolean jabber_handle_is_self( struct im_connection *ic, const char *who ) {
+	struct jabber_data *jd = ic->proto_data;
+	return ( ( g_strcasecmp( who, ic->acc->user ) == 0 ) ||
+		 ( jd->internal_jid &&
+		   g_strcasecmp( who, jd->internal_jid ) == 0 ) );
+}
+
 void jabber_initmodule()
 {
 	struct prpl *ret = g_new0( struct prpl, 1 );
@@ -647,6 +655,7 @@ void jabber_initmodule()
 	ret->keepalive = jabber_keepalive;
 	ret->send_typing = jabber_send_typing;
 	ret->handle_cmp = g_strcasecmp;
+	ret->handle_is_self = jabber_handle_is_self;
 	ret->transfer_request = jabber_si_transfer_request;
 	ret->buddy_action_list = jabber_buddy_action_list;
 	ret->buddy_action = jabber_buddy_action;

--- a/protocols/jabber/jabber.h
+++ b/protocols/jabber/jabber.h
@@ -96,6 +96,7 @@ struct jabber_data
 	char *username;		/* USERNAME@server */
 	char *server;		/* username@SERVER -=> server/domain, not hostname */
 	char *me;		/* bare jid */
+	char *internal_jid;
 	
 	const struct oauth2_service *oauth2_service;
 	char *oauth2_access_token;

--- a/protocols/jabber/jabber_util.c
+++ b/protocols/jabber/jabber_util.c
@@ -823,6 +823,10 @@ gboolean jabber_set_me( struct im_connection *ic, const char *me )
 	jd->server = strchr( jd->me, '@' );
 	jd->username = g_strndup( jd->me, jd->server - jd->me );
 	jd->server ++;
+
+	/* Set the "internal" account username, for groupchats */
+	g_free( jd->internal_jid );
+	jd->internal_jid = g_strdup( jd->me );
 	
 	return TRUE;
 }

--- a/protocols/nogaim.c
+++ b/protocols/nogaim.c
@@ -293,6 +293,17 @@ void imcb_connected( struct im_connection *ic )
 	   function should be handled correctly. (IOW, ignored) */
 	if( ic->flags & OPT_LOGGED_IN )
 		return;
+
+	if( ic->acc->flags & ACC_FLAG_LOCAL )
+	{
+		GHashTableIter nicks;
+		gpointer k, v;
+		g_hash_table_iter_init( &nicks, ic->acc->nicks );
+		while( g_hash_table_iter_next( &nicks, &k, &v ) )
+		{
+			ic->acc->prpl->add_buddy( ic, (char*) k, NULL );
+		}
+	}
 	
 	imcb_log( ic, "Logged in" );
 	

--- a/protocols/nogaim.h
+++ b/protocols/nogaim.h
@@ -262,6 +262,9 @@ struct prpl {
 	GList *(* buddy_action_list) (struct bee_user *bu);
 	void *(* buddy_action) (struct bee_user *bu, const char *action, char * const args[], void *data);
 	
+	/* If null, equivalent to handle_cmp( ic->acc->user, who ) */
+	gboolean (* handle_is_self) (struct im_connection *, const char *who);
+
 	/* Some placeholders so eventually older plugins may cooperate with newer BitlBees. */
 	void *resv1;
 	void *resv2;

--- a/protocols/oscar/chat.c
+++ b/protocols/oscar/chat.c
@@ -66,7 +66,8 @@ int aim_chat_send_im(aim_session_t *sess, aim_conn_t *conn, guint16 flags, const
 	 *
 	 */
 	for (i = 0; i < sizeof(ckstr); i++)
-		aimutil_put8(ckstr+i, (guint8) rand());
+		(void) aimutil_put8(ckstr+i, (guint8) rand());
+	
 
 	cookie = aim_mkcookie(ckstr, AIM_COOKIETYPE_CHAT, NULL);
 	cookie->data = NULL; /* XXX store something useful here */
@@ -227,7 +228,7 @@ int aim_chat_invite(aim_session_t *sess, aim_conn_t *conn, const char *sn, const
 	 * Cookie
 	 */
 	for (i = 0; i < sizeof(ckstr); i++)
-		aimutil_put8(ckstr, (guint8) rand());
+		(void) aimutil_put8(ckstr, (guint8) rand());
 
 	/* XXX should be uncached by an unwritten 'invite accept' handler */
 	if ((priv = g_malloc(sizeof(struct aim_invite_priv)))) {

--- a/protocols/oscar/tlv.c
+++ b/protocols/oscar/tlv.c
@@ -180,7 +180,7 @@ int aim_addtlvtochain8(aim_tlvlist_t **list, const guint16 t, const guint8 v)
 {
 	guint8 v8[1];
 
-	aimutil_put8(v8, v);
+	(void) aimutil_put8(v8, v);
 
 	return aim_addtlvtochain_raw(list, t, 1, v8);
 }
@@ -198,7 +198,7 @@ int aim_addtlvtochain16(aim_tlvlist_t **list, const guint16 t, const guint16 v)
 {
 	guint8 v16[2];
 
-	aimutil_put16(v16, v);
+	(void) aimutil_put16(v16, v);
 
 	return aim_addtlvtochain_raw(list, t, 2, v16);
 }
@@ -216,7 +216,7 @@ int aim_addtlvtochain32(aim_tlvlist_t **list, const guint16 t, const guint32 v)
 {
 	guint8 v32[4];
 
-	aimutil_put32(v32, v);
+	(void) aimutil_put32(v32, v);
 
 	return aim_addtlvtochain_raw(list, t, 4, v32);
 }


### PR DESCRIPTION
* Silence some oscar compilation warnings
    * Unused values due to weird macros. Pidgin "fixed" it the same way. Nothing too weird.
* Add handle_is_self() prpl function to fix JID mismatch confusion bugs
    * An earlier version of this commit had a bug with non-jabber protocols - it's been fixed already
    * LGTM'd by wilmer already, he's the one who requested a prpl function for it.
    * Part of my hip-cat branch
* jabber: Account-wide display_name setting, for groupchats
    * Part of my hip-cat branch
* Fix whatsapp local contact lists
    * Actually just improves slightly over the existing gadugadu patch.