### PR TITLE
Reorganize include files to avoid conflicts with other libs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@
 
 # Program variables
 objects = bitlbee.o dcc.o help.o ipc.o irc.o irc_im.o irc_channel.o irc_commands.o irc_send.o irc_user.o irc_util.o nick.o $(OTR_BI) query.o root_commands.o set.o storage.o $(STORAGE_OBJS) unix.o conf.o log.o
-headers = $(wildcard $(_SRCDIR_)*.h $(_SRCDIR_)lib/*.h $(_SRCDIR_)protocols/*.h)
+headers = $(foreach dir,./ ./lib/ ./protocols/,$(patsubst $(_SRCDIR_)%,%,$(wildcard $(_SRCDIR_)$(dir)*.h)))
 subdirs = lib protocols
 
 OUTFILE = bitlbee
@@ -91,15 +91,15 @@ uninstall-bin:
 	rm -f $(DESTDIR)$(SBINDIR)/$(OUTFILE)
 
 install-dev:
-	mkdir -p $(DESTDIR)$(INCLUDEDIR)
+	mkdir -p $(DESTDIR)$(INCLUDEDIR) $(DESTDIR)$(INCLUDEDIR)lib $(DESTDIR)$(INCLUDEDIR)protocols
 	$(INSTALL) -m 0644 config.h $(DESTDIR)$(INCLUDEDIR)
-	for i in $(headers); do $(INSTALL) -m 0644 $$i $(DESTDIR)$(INCLUDEDIR); done
+	for i in $(headers); do $(INSTALL) -m 0644 $(_SRCDIR_)$$i $(DESTDIR)$(INCLUDEDIR)$$i; done
 	mkdir -p $(DESTDIR)$(PCDIR)
 	$(INSTALL) -m 0644 bitlbee.pc $(DESTDIR)$(PCDIR)
 
 uninstall-dev:
-	rm -f $(foreach hdr,$(headers),$(DESTDIR)$(INCLUDEDIR)/$(hdr))
-	-rmdir $(DESTDIR)$(INCLUDEDIR)
+	rm -f $(foreach hdr,$(headers),$(DESTDIR)$(INCLUDEDIR)$(hdr))
+	-rmdir $(DESTDIR)$(INCLUDEDIR)lib $(DESTDIR)$(INCLUDEDIR)protocols $(DESTDIR)$(INCLUDEDIR)
 	rm -f $(DESTDIR)$(PCDIR)/bitlbee.pc
 
 install-etc:

--- a/bitlbee.h
+++ b/bitlbee.h
@@ -43,7 +43,7 @@ extern "C" {
 #define MAX_STRING 511
 
 #if HAVE_CONFIG_H
-#include <config.h>
+#include "config.h"
 #endif
 
 #include <fcntl.h>
@@ -131,21 +131,21 @@ extern "C" {
    this password set, use /OPER to change it. */
 #define PASSWORD_PENDING "\r\rchangeme\r\r"
 
-#include "bee.h"
+#include "protocols/bee.h"
 #include "irc.h"
 #include "storage.h"
 #include "set.h"
-#include "nogaim.h"
+#include "protocols/nogaim.h"
 #include "commands.h"
-#include "account.h"
+#include "protocols/account.h"
 #include "nick.h"
 #include "conf.h"
 #include "log.h"
-#include "ini.h"
+#include "lib/ini.h"
 #include "query.h"
 #include "sock.h"
-#include "misc.h"
-#include "proxy.h"
+#include "lib/misc.h"
+#include "lib/proxy.h"
 
 typedef struct global {
 	/* In forked mode, child processes store the fd of the IPC socket here. */

--- a/conf.c
+++ b/conf.c
@@ -29,11 +29,11 @@
 #include <string.h>
 #include <stdlib.h>
 #include "conf.h"
-#include "ini.h"
-#include "url.h"
+#include "lib/ini.h"
+#include "lib/url.h"
 #include "ipc.h"
 
-#include "proxy.h"
+#include "lib/proxy.h"
 
 static int conf_loadini(conf_t *conf, char *file);
 

--- a/configure
+++ b/configure
@@ -230,7 +230,7 @@ fi
 echo LDFLAGS=$LDFLAGS >> Makefile.settings
 
 echo CFLAGS=$CFLAGS $CPPFLAGS >> Makefile.settings
-echo CFLAGS+=-I${srcdir} -I${srcdir}/lib -I${srcdir}/protocols -I. >> Makefile.settings
+echo CFLAGS+=-I${srcdir} >> Makefile.settings
 
 echo CFLAGS+=-DHAVE_CONFIG_H -D_GNU_SOURCE >> Makefile.settings
 
@@ -706,7 +706,7 @@ Description: IRC to IM gateway
 Requires: glib-2.0
 Version: $BITLBEE_VERSION
 Libs:
-Cflags: -I\${includedir}
+Cflags:
 
 EOF
 

--- a/dcc.c
+++ b/dcc.c
@@ -23,7 +23,7 @@
 
 #define BITLBEE_CORE
 #include "bitlbee.h"
-#include "ft.h"
+#include "protocols/ft.h"
 #include "dcc.h"
 #include <netinet/tcp.h>
 #include <regex.h>

--- a/lib/arc.c
+++ b/lib/arc.c
@@ -44,8 +44,8 @@
 #include <gmodule.h>
 #include <stdlib.h>
 #include <string.h>
-#include "misc.h"
-#include "arc.h"
+#include "lib/misc.h"
+#include "lib/arc.h"
 
 /* Add some seed to the password, to make sure we *never* use the same key.
    This defines how many bytes we use as a seed. */

--- a/lib/base64.c
+++ b/lib/base64.c
@@ -24,7 +24,7 @@
 
 #include <glib.h>
 #include <string.h>
-#include "base64.h"
+#include "lib/base64.h"
 
 char *tobase64(const char *text)
 {

--- a/lib/events_glib.c
+++ b/lib/events_glib.c
@@ -37,7 +37,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <errno.h>
-#include "proxy.h"
+#include "lib/proxy.h"
 
 typedef struct _GaimIOClosure {
 	b_event_handler function;

--- a/lib/events_libevent.c
+++ b/lib/events_libevent.c
@@ -33,7 +33,7 @@
 #include <sys/types.h>
 #include <sys/time.h>
 #include <event.h>
-#include "proxy.h"
+#include "lib/proxy.h"
 
 static void b_main_restart();
 static guint id_next = 1; /* Next ID to be allocated to an event handler. */

--- a/lib/http_client.c
+++ b/lib/http_client.c
@@ -26,8 +26,8 @@
 #include <string.h>
 #include <stdio.h>
 
-#include "http_client.h"
-#include "url.h"
+#include "lib/http_client.h"
+#include "lib/url.h"
 #include "sock.h"
 
 

--- a/lib/http_client.h
+++ b/lib/http_client.h
@@ -33,7 +33,7 @@
    alives. */
 
 #include <glib.h>
-#include "ssl_client.h"
+#include "lib/ssl_client.h"
 
 struct http_request;
 

--- a/lib/json.c
+++ b/lib/json.c
@@ -29,7 +29,7 @@
 
 #include <glib.h>
 
-#include "json.h"
+#include "lib/json.h"
 
 #ifdef _MSC_VER
    #ifndef _CRT_SECURE_NO_WARNINGS

--- a/lib/json_util.c
+++ b/lib/json_util.c
@@ -25,7 +25,7 @@
 #include <string.h>
 #include <glib.h>
 
-#include "json_util.h"
+#include "lib/json_util.h"
 
 json_value *json_o_get(const json_value *obj, const json_char *name)
 {

--- a/lib/json_util.h
+++ b/lib/json_util.h
@@ -21,7 +21,7 @@
 *                                                                           *
 ****************************************************************************/
 
-#include "json.h"
+#include "lib/json.h"
 
 #define JSON_O_FOREACH(o, k, v) \
 	char *k; json_value *v; int __i; \

--- a/lib/md5.c
+++ b/lib/md5.c
@@ -1,4 +1,4 @@
-#include "md5.h"
+#include "lib/md5.h"
 
 /* Creates a new GChecksum in ctx */
 void md5_init(md5_state_t *ctx)

--- a/lib/misc.c
+++ b/lib/misc.c
@@ -31,9 +31,9 @@
 */
 
 #define BITLBEE_CORE
-#include "nogaim.h"
-#include "base64.h"
-#include "md5.h"
+#include "protocols/nogaim.h"
+#include "lib/base64.h"
+#include "lib/md5.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -46,8 +46,8 @@
 #include <resolv.h>
 #endif
 
-#include "md5.h"
-#include "ssl_client.h"
+#include "lib/md5.h"
+#include "lib/ssl_client.h"
 
 void strip_linefeed(gchar *text)
 {

--- a/lib/oauth.c
+++ b/lib/oauth.c
@@ -25,12 +25,12 @@
 #include <gmodule.h>
 #include <stdlib.h>
 #include <string.h>
-#include "http_client.h"
-#include "base64.h"
-#include "misc.h"
-#include "sha1.h"
-#include "url.h"
-#include "oauth.h"
+#include "lib/http_client.h"
+#include "lib/base64.h"
+#include "lib/misc.h"
+#include "lib/sha1.h"
+#include "lib/url.h"
+#include "lib/oauth.h"
 
 #define HMAC_BLOCK_SIZE 64
 

--- a/lib/oauth2.c
+++ b/lib/oauth2.c
@@ -38,12 +38,12 @@
    http://hueniverse.com/2012/07/oauth-2-0-and-the-road-to-hell/ */
 
 #include <glib.h>
-#include "http_client.h"
-#include "oauth2.h"
-#include "oauth.h"
-#include "json.h"
-#include "json_util.h"
-#include "url.h"
+#include "lib/http_client.h"
+#include "lib/oauth2.h"
+#include "lib/oauth.h"
+#include "lib/json.h"
+#include "lib/json_util.h"
+#include "lib/url.h"
 
 char *oauth2_url(const struct oauth2_service *sp)
 {

--- a/lib/proxy.c
+++ b/lib/proxy.c
@@ -32,9 +32,9 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <errno.h>
-#include "nogaim.h"
-#include "proxy.h"
-#include "base64.h"
+#include "protocols/nogaim.h"
+#include "lib/proxy.h"
+#include "lib/base64.h"
 
 char proxyhost[128] = "";
 int proxyport = 0;

--- a/lib/proxy.h
+++ b/lib/proxy.h
@@ -33,7 +33,7 @@
 #include <glib.h>
 #include <gmodule.h>
 
-#include "events.h"
+#include "lib/events.h"
 
 #define PROXY_NONE 0
 #define PROXY_HTTP 1

--- a/lib/sha1.c
+++ b/lib/sha1.c
@@ -1,6 +1,7 @@
-#include "sha1.h"
+#include "lib/sha1.h"
 #include <string.h>
 #include <stdio.h>
+
 
 
 void sha1_init(sha1_state_t *ctx)

--- a/lib/ssl_client.h
+++ b/lib/ssl_client.h
@@ -32,7 +32,7 @@
    is completed. */
 
 #include <glib.h>
-#include "proxy.h"
+#include "lib/proxy.h"
 
 /* Some generic error codes. Especially SSL_AGAIN is important if you
    want to do asynchronous I/O. */

--- a/lib/ssl_gnutls.c
+++ b/lib/ssl_gnutls.c
@@ -28,8 +28,8 @@
 #include <gcrypt.h>
 #include <fcntl.h>
 #include <unistd.h>
-#include "proxy.h"
-#include "ssl_client.h"
+#include "lib/proxy.h"
+#include "lib/ssl_client.h"
 #include "sock.h"
 #include "stdlib.h"
 #include "bitlbee.h"

--- a/lib/ssl_nss.c
+++ b/lib/ssl_nss.c
@@ -26,8 +26,8 @@
 */
 
 #include "bitlbee.h"
-#include "proxy.h"
-#include "ssl_client.h"
+#include "lib/proxy.h"
+#include "lib/ssl_client.h"
 #include "sock.h"
 #include <nspr.h>
 #include <prio.h>

--- a/lib/ssl_openssl.c
+++ b/lib/ssl_openssl.c
@@ -31,8 +31,8 @@
 #include <openssl/err.h>
 
 #include "bitlbee.h"
-#include "proxy.h"
-#include "ssl_client.h"
+#include "lib/proxy.h"
+#include "lib/ssl_client.h"
 #include "sock.h"
 
 int ssl_errno = 0;

--- a/lib/url.c
+++ b/lib/url.c
@@ -23,7 +23,7 @@
   Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-#include "url.h"
+#include "lib/url.h"
 
 /* Convert an URL to a url_t structure */
 int url_set(url_t *url, const char *set_url)

--- a/lib/xmltree.c
+++ b/lib/xmltree.c
@@ -27,7 +27,7 @@
 #include <ctype.h>
 #include <stdio.h>
 
-#include "xmltree.h"
+#include "lib/xmltree.h"
 
 #define g_strcasecmp g_ascii_strcasecmp
 #define g_strncasecmp g_ascii_strncasecmp

--- a/protocols/account.c
+++ b/protocols/account.c
@@ -25,7 +25,7 @@
 
 #define BITLBEE_CORE
 #include "bitlbee.h"
-#include "account.h"
+#include "protocols/account.h"
 
 static const char* account_protocols_local[] = {
 	"gg", "whatsapp", NULL

--- a/protocols/bee_ft.c
+++ b/protocols/bee_ft.c
@@ -23,7 +23,7 @@
 
 #define BITLBEE_CORE
 #include "bitlbee.h"
-#include "ft.h"
+#include "protocols/ft.h"
 
 file_transfer_t *imcb_file_send_start(struct im_connection *ic, char *handle, char *file_name, size_t file_size)
 {

--- a/protocols/jabber/conference.c
+++ b/protocols/jabber/conference.c
@@ -22,7 +22,7 @@
 \***************************************************************************/
 
 #include "jabber.h"
-#include "sha1.h"
+#include "lib/sha1.h"
 
 static xt_status jabber_chat_join_failed(struct im_connection *ic, struct xt_node *node, struct xt_node *orig);
 

--- a/protocols/jabber/io.c
+++ b/protocols/jabber/io.c
@@ -22,7 +22,7 @@
 \***************************************************************************/
 
 #include "jabber.h"
-#include "ssl_client.h"
+#include "lib/ssl_client.h"
 
 static gboolean jabber_write_callback(gpointer data, gint fd, b_input_condition cond);
 static gboolean jabber_write_queue(struct im_connection *ic);

--- a/protocols/jabber/iq.c
+++ b/protocols/jabber/iq.c
@@ -22,7 +22,7 @@
 \***************************************************************************/
 
 #include "jabber.h"
-#include "sha1.h"
+#include "lib/sha1.h"
 
 static xt_status jabber_parse_roster(struct im_connection *ic, struct xt_node *node, struct xt_node *orig);
 static xt_status jabber_iq_display_vcard(struct im_connection *ic, struct xt_node *node, struct xt_node *orig);

--- a/protocols/jabber/jabber.c
+++ b/protocols/jabber/jabber.c
@@ -27,12 +27,12 @@
 #include <ctype.h>
 #include <stdio.h>
 
-#include "ssl_client.h"
-#include "xmltree.h"
+#include "lib/ssl_client.h"
+#include "lib/xmltree.h"
 #include "bitlbee.h"
 #include "jabber.h"
-#include "oauth.h"
-#include "md5.h"
+#include "lib/oauth.h"
+#include "lib/md5.h"
 
 GSList *jabber_connections;
 

--- a/protocols/jabber/jabber.h
+++ b/protocols/jabber/jabber.h
@@ -27,8 +27,8 @@
 #include <glib.h>
 
 #include "bitlbee.h"
-#include "md5.h"
-#include "xmltree.h"
+#include "lib/md5.h"
+#include "lib/xmltree.h"
 
 extern GSList *jabber_connections;
 

--- a/protocols/jabber/jabber_util.c
+++ b/protocols/jabber/jabber_util.c
@@ -22,8 +22,8 @@
 \***************************************************************************/
 
 #include "jabber.h"
-#include "md5.h"
-#include "base64.h"
+#include "lib/md5.h"
+#include "lib/base64.h"
 
 static unsigned int next_id = 1;
 

--- a/protocols/jabber/s5bytestream.c
+++ b/protocols/jabber/s5bytestream.c
@@ -22,7 +22,7 @@
 \***************************************************************************/
 
 #include "jabber.h"
-#include "sha1.h"
+#include "lib/sha1.h"
 #include "lib/ftutil.h"
 #include <poll.h>
 

--- a/protocols/jabber/sasl.c
+++ b/protocols/jabber/sasl.c
@@ -24,9 +24,9 @@
 #include <ctype.h>
 
 #include "jabber.h"
-#include "base64.h"
-#include "oauth2.h"
-#include "oauth.h"
+#include "lib/base64.h"
+#include "lib/oauth2.h"
+#include "lib/oauth.h"
 
 const struct oauth2_service oauth2_service_google =
 {

--- a/protocols/jabber/si.c
+++ b/protocols/jabber/si.c
@@ -22,7 +22,7 @@
 \***************************************************************************/
 
 #include "jabber.h"
-#include "sha1.h"
+#include "lib/sha1.h"
 
 void jabber_si_answer_request(file_transfer_t *ft);
 int jabber_si_send_request(struct im_connection *ic, char *who, struct jabber_transfer *tf);

--- a/protocols/msn/msn.c
+++ b/protocols/msn/msn.c
@@ -23,7 +23,7 @@
   Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-#include "nogaim.h"
+#include "protocols/nogaim.h"
 #include "soap.h"
 #include "msn.h"
 

--- a/protocols/msn/msn_util.c
+++ b/protocols/msn/msn_util.c
@@ -23,9 +23,9 @@
   Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-#include "nogaim.h"
+#include "protocols/nogaim.h"
 #include "msn.h"
-#include "md5.h"
+#include "lib/md5.h"
 #include "soap.h"
 #include <ctype.h>
 

--- a/protocols/msn/ns.c
+++ b/protocols/msn/ns.c
@@ -25,12 +25,12 @@
 
 #include <ctype.h>
 #include <sys/utsname.h>
-#include "nogaim.h"
+#include "protocols/nogaim.h"
 #include "msn.h"
-#include "md5.h"
-#include "sha1.h"
+#include "lib/md5.h"
+#include "lib/sha1.h"
 #include "soap.h"
-#include "xmltree.h"
+#include "lib/xmltree.h"
 
 static gboolean msn_ns_connected(gpointer data, gint source, b_input_condition cond);
 static gboolean msn_ns_callback(gpointer data, gint source, b_input_condition cond);

--- a/protocols/msn/sb.c
+++ b/protocols/msn/sb.c
@@ -24,9 +24,9 @@
 */
 
 #include <ctype.h>
-#include "nogaim.h"
+#include "protocols/nogaim.h"
 #include "msn.h"
-#include "md5.h"
+#include "lib/md5.h"
 #include "soap.h"
 #include "invitation.h"
 

--- a/protocols/msn/soap.c
+++ b/protocols/msn/soap.c
@@ -26,15 +26,15 @@
   Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-#include "http_client.h"
+#include "lib/http_client.h"
 #include "soap.h"
 #include "msn.h"
 #include "bitlbee.h"
-#include "url.h"
-#include "misc.h"
-#include "sha1.h"
-#include "base64.h"
-#include "xmltree.h"
+#include "lib/url.h"
+#include "lib/misc.h"
+#include "lib/sha1.h"
+#include "lib/base64.h"
+#include "lib/xmltree.h"
 #include <ctype.h>
 #include <errno.h>
 

--- a/protocols/msn/soap.h
+++ b/protocols/msn/soap.h
@@ -39,7 +39,7 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <unistd.h>
-#include "nogaim.h"
+#include "protocols/nogaim.h"
 
 
 int msn_soapq_flush(struct im_connection *ic, gboolean resend);

--- a/protocols/msn/tables.c
+++ b/protocols/msn/tables.c
@@ -23,7 +23,7 @@
   Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-#include "nogaim.h"
+#include "protocols/nogaim.h"
 #include "msn.h"
 
 const struct msn_away_state msn_away_state_list[] =

--- a/protocols/nogaim.c
+++ b/protocols/nogaim.c
@@ -34,7 +34,7 @@
 #define BITLBEE_CORE
 #include <ctype.h>
 
-#include "nogaim.h"
+#include "protocols/nogaim.h"
 
 GSList *connections;
 

--- a/protocols/nogaim.h
+++ b/protocols/nogaim.h
@@ -45,11 +45,11 @@
 #endif
 
 #include "bitlbee.h"
-#include "account.h"
-#include "proxy.h"
+#include "protocols/account.h"
+#include "lib/proxy.h"
 #include "query.h"
-#include "md5.h"
-#include "ft.h"
+#include "lib/md5.h"
+#include "protocols/ft.h"
 
 #define BUDDY_ALIAS_MAXLEN 388   /* because MSN names can be 387 characters */
 

--- a/protocols/oscar/admin.c
+++ b/protocols/oscar/admin.c
@@ -1,4 +1,4 @@
-#include <aim.h>
+#include "aim.h"
 #include "admin.h"
 
 /* called for both reply and change-reply */

--- a/protocols/oscar/aim.h
+++ b/protocols/oscar/aim.h
@@ -791,7 +791,7 @@ int aim_chatnav_createroom(aim_session_t *sess, aim_conn_t *conn, const char *na
 
 int aim_sncmp(const char *a, const char *b);
 
-#include <aim_internal.h>
+#include "aim_internal.h"
 
 /*
  * SNAC Families.

--- a/protocols/oscar/auth.c
+++ b/protocols/oscar/auth.c
@@ -3,9 +3,9 @@
  *
  */
 
-#include <aim.h>
+#include "aim.h"
 
-#include "md5.h"
+#include "lib/md5.h"
 
 static int aim_encode_password(const char *password, unsigned char *encoded);
 

--- a/protocols/oscar/bos.c
+++ b/protocols/oscar/bos.c
@@ -1,4 +1,4 @@
-#include <aim.h>
+#include "aim.h"
 #include "bos.h"
 
 /* Request BOS rights (group 9, type 2) */

--- a/protocols/oscar/buddylist.c
+++ b/protocols/oscar/buddylist.c
@@ -1,4 +1,4 @@
-#include <aim.h>
+#include "aim.h"
 #include "buddylist.h"
 
 /*

--- a/protocols/oscar/chat.c
+++ b/protocols/oscar/chat.c
@@ -5,7 +5,7 @@
  *
  */
 
-#include <aim.h>
+#include "aim.h"
 #include <glib.h>
 #include "info.h"
 

--- a/protocols/oscar/chatnav.c
+++ b/protocols/oscar/chatnav.c
@@ -7,7 +7,7 @@
  *
  */
 
-#include <aim.h>
+#include "aim.h"
 #include "chatnav.h"
 
 /*

--- a/protocols/oscar/conn.c
+++ b/protocols/oscar/conn.c
@@ -6,7 +6,7 @@
  *
  */
 
-#include <aim.h>
+#include "aim.h"
 #include "sock.h"
 
 static int aim_logoff(aim_session_t *sess);

--- a/protocols/oscar/icq.c
+++ b/protocols/oscar/icq.c
@@ -3,7 +3,7 @@
  *
  */
 
-#include <aim.h>
+#include "aim.h"
 #include "icq.h"
 
 int aim_icq_reqofflinemsgs(aim_session_t *sess)

--- a/protocols/oscar/im.c
+++ b/protocols/oscar/im.c
@@ -19,7 +19,7 @@
  *
  */
 
-#include <aim.h>
+#include "aim.h"
 #include "im.h"
 #include "info.h"
 

--- a/protocols/oscar/info.c
+++ b/protocols/oscar/info.c
@@ -6,7 +6,7 @@
  *
  */
 
-#include <aim.h>
+#include "aim.h"
 #include "info.h"
 
 struct aim_priv_inforeq {

--- a/protocols/oscar/misc.c
+++ b/protocols/oscar/misc.c
@@ -11,7 +11,7 @@
  *
  */
 
-#include <aim.h>
+#include "aim.h"
 
 /*
  * aim_bos_setprofile(profile)

--- a/protocols/oscar/msgcookie.c
+++ b/protocols/oscar/msgcookie.c
@@ -11,7 +11,7 @@
  * wrong, we get quirky behavior when cookies step on each others' toes.
  */
 
-#include <aim.h>
+#include "aim.h"
 #include "info.h"
 
 /**

--- a/protocols/oscar/oscar.c
+++ b/protocols/oscar/oscar.c
@@ -30,9 +30,9 @@
 #include <time.h>
 #include <sys/stat.h>
 #include <glib.h>
-#include "nogaim.h"
+#include "protocols/nogaim.h"
 #include "bitlbee.h"
-#include "proxy.h"
+#include "lib/proxy.h"
 #include "sock.h"
 
 #include "aim.h"

--- a/protocols/oscar/oscar_util.c
+++ b/protocols/oscar/oscar_util.c
@@ -1,4 +1,4 @@
-#include <aim.h>
+#include "aim.h"
 #include <ctype.h>
 
 /*

--- a/protocols/oscar/rxhandlers.c
+++ b/protocols/oscar/rxhandlers.c
@@ -7,7 +7,7 @@
  *
  */
 
-#include <aim.h>
+#include "aim.h"
 
 struct aim_rxcblist_s {
 	guint16 family;

--- a/protocols/oscar/rxqueue.c
+++ b/protocols/oscar/rxqueue.c
@@ -6,7 +6,7 @@
  * aim_rxhandlers.c.
  */
 
-#include <aim.h>
+#include "aim.h"
 
 #include <sys/socket.h>
 

--- a/protocols/oscar/search.c
+++ b/protocols/oscar/search.c
@@ -6,7 +6,7 @@
  *
  */
 
-#include <aim.h>
+#include "aim.h"
 
 /* XXX can this be integrated with the rest of the error handling? */
 static int error(aim_session_t *sess, aim_module_t *mod, aim_frame_t *rx, aim_modsnac_t *snac, aim_bstream_t *bs)

--- a/protocols/oscar/service.c
+++ b/protocols/oscar/service.c
@@ -3,9 +3,9 @@
  * this group, as it does some particularly good things (like rate limiting).
  */
 
-#include <aim.h>
+#include "aim.h"
 
-#include "md5.h"
+#include "lib/md5.h"
 
 /* Client Online (group 1, subtype 2) */
 int aim_clientready(aim_session_t *sess, aim_conn_t *conn)

--- a/protocols/oscar/snac.c
+++ b/protocols/oscar/snac.c
@@ -12,7 +12,7 @@
  *
  */
 
-#include <aim.h>
+#include "aim.h"
 
 static aim_snacid_t aim_newsnac(aim_session_t *sess, aim_snac_t *newsnac);
 

--- a/protocols/oscar/ssi.c
+++ b/protocols/oscar/ssi.c
@@ -22,7 +22,7 @@
  *
  */
 
-#include <aim.h>
+#include "aim.h"
 #include "ssi.h"
 
 /**

--- a/protocols/oscar/stats.c
+++ b/protocols/oscar/stats.c
@@ -1,5 +1,5 @@
 
-#include <aim.h>
+#include "aim.h"
 
 static int reportinterval(aim_session_t *sess, aim_module_t *mod, aim_frame_t *rx, aim_modsnac_t *snac,
                           aim_bstream_t *bs)

--- a/protocols/oscar/tlv.c
+++ b/protocols/oscar/tlv.c
@@ -1,4 +1,4 @@
-#include <aim.h>
+#include "aim.h"
 
 static void freetlv(aim_tlv_t **oldtlv)
 {

--- a/protocols/oscar/txqueue.c
+++ b/protocols/oscar/txqueue.c
@@ -5,7 +5,7 @@
  *
  */
 
-#include <aim.h>
+#include "aim.h"
 #include "im.h"
 
 #include <sys/socket.h>

--- a/protocols/skype/skype.c
+++ b/protocols/skype/skype.c
@@ -23,8 +23,8 @@
 #define _BSD_SOURCE
 #include <poll.h>
 #include <stdio.h>
-#include <bitlbee.h>
-#include <ssl_client.h>
+#include "bitlbee.h"
+#include "lib/ssl_client.h"
 
 #define SKYPE_DEFAULT_SERVER "localhost"
 #define SKYPE_DEFAULT_PORT "2727"

--- a/protocols/twitter/twitter.c
+++ b/protocols/twitter/twitter.c
@@ -22,12 +22,12 @@
 *                                                                           *
 ****************************************************************************/
 
-#include "nogaim.h"
-#include "oauth.h"
+#include "protocols/nogaim.h"
+#include "lib/oauth.h"
 #include "twitter.h"
 #include "twitter_http.h"
 #include "twitter_lib.h"
-#include "url.h"
+#include "lib/url.h"
 
 GSList *twitter_connections = NULL;
 

--- a/protocols/twitter/twitter.h
+++ b/protocols/twitter/twitter.h
@@ -22,7 +22,7 @@
 *                                                                           *
 ****************************************************************************/
 
-#include "nogaim.h"
+#include "protocols/nogaim.h"
 
 #ifndef _TWITTER_H
 #define _TWITTER_H

--- a/protocols/twitter/twitter_http.c
+++ b/protocols/twitter/twitter_http.c
@@ -30,10 +30,10 @@
 
 #include "twitter.h"
 #include "bitlbee.h"
-#include "url.h"
-#include "misc.h"
-#include "base64.h"
-#include "oauth.h"
+#include "lib/url.h"
+#include "lib/misc.h"
+#include "lib/base64.h"
+#include "lib/oauth.h"
 #include <ctype.h>
 #include <errno.h>
 

--- a/protocols/twitter/twitter_http.h
+++ b/protocols/twitter/twitter_http.h
@@ -24,8 +24,8 @@
 #ifndef _TWITTER_HTTP_H
 #define _TWITTER_HTTP_H
 
-#include "nogaim.h"
-#include "http_client.h"
+#include "protocols/nogaim.h"
+#include "lib/http_client.h"
 
 typedef enum {
 	/* With this set, twitter_http_post() will post a generic confirmation

--- a/protocols/twitter/twitter_lib.c
+++ b/protocols/twitter/twitter_lib.c
@@ -31,11 +31,11 @@
 #include "twitter_http.h"
 #include "twitter.h"
 #include "bitlbee.h"
-#include "url.h"
-#include "misc.h"
-#include "base64.h"
+#include "lib/url.h"
+#include "lib/misc.h"
+#include "lib/base64.h"
 #include "twitter_lib.h"
-#include "json_util.h"
+#include "lib/json_util.h"
 #include <ctype.h>
 #include <errno.h>
 

--- a/protocols/twitter/twitter_lib.h
+++ b/protocols/twitter/twitter_lib.h
@@ -25,7 +25,7 @@
 #ifndef _TWITTER_LIB_H
 #define _TWITTER_LIB_H
 
-#include "nogaim.h"
+#include "protocols/nogaim.h"
 #include "twitter_http.h"
 
 #define TWITTER_API_URL "https://api.twitter.com/1.1"

--- a/protocols/yahoo/libyahoo2.c
+++ b/protocols/yahoo/libyahoo2.c
@@ -75,8 +75,8 @@ char *strchr(), *strrchr();
 #include <stdlib.h>
 #include <ctype.h>
 
-#include "sha1.h"
-#include "md5.h"
+#include "lib/sha1.h"
+#include "lib/md5.h"
 #include "yahoo2.h"
 #include "yahoo_httplib.h"
 #include "yahoo_util.h"
@@ -88,8 +88,8 @@ char *strchr(), *strrchr();
 #define vsnprintf _vsnprintf
 #endif
 
-#include "base64.h"
-#include "http_client.h"
+#include "lib/base64.h"
+#include "lib/http_client.h"
 
 #ifdef USE_STRUCT_CALLBACKS
 struct yahoo_callbacks *yc = NULL;

--- a/protocols/yahoo/yahoo.c
+++ b/protocols/yahoo/yahoo.c
@@ -27,7 +27,7 @@
 #include <time.h>
 #include <sys/stat.h>
 #include <ctype.h>
-#include "nogaim.h"
+#include "protocols/nogaim.h"
 #include "yahoo2.h"
 #include "yahoo2_callbacks.h"
 

--- a/storage_xml.c
+++ b/storage_xml.c
@@ -25,10 +25,10 @@
 
 #define BITLBEE_CORE
 #include "bitlbee.h"
-#include "base64.h"
-#include "arc.h"
-#include "md5.h"
-#include "xmltree.h"
+#include "lib/base64.h"
+#include "lib/arc.h"
+#include "lib/md5.h"
+#include "lib/xmltree.h"
 
 #include <glib/gstdio.h>
 

--- a/tests/check_arc.c
+++ b/tests/check_arc.c
@@ -4,7 +4,7 @@
 #include <check.h>
 #include <string.h>
 #include <stdio.h>
-#include "arc.h"
+#include "lib/arc.h"
 
 char *password = "ArcVier";
 

--- a/tests/check_jabber_util.c
+++ b/tests/check_jabber_util.c
@@ -4,7 +4,7 @@
 #include <check.h>
 #include <string.h>
 #include <stdio.h>
-#include "jabber/jabber.h"
+#include "protocols/jabber/jabber.h"
 
 static struct im_connection *ic;
 

--- a/tests/check_md5.c
+++ b/tests/check_md5.c
@@ -4,7 +4,7 @@
 #include <check.h>
 #include <string.h>
 #include <stdio.h>
-#include "md5.h"
+#include "lib/md5.h"
 
 /* From RFC 1321 */
 struct md5_test {

--- a/tests/check_nick.c
+++ b/tests/check_nick.c
@@ -5,7 +5,7 @@
 #include <string.h>
 #include "irc.h"
 #include "set.h"
-#include "misc.h"
+#include "lib/misc.h"
 #include "bitlbee.h"
 
 START_TEST(test_nick_strip){

--- a/tests/check_util.c
+++ b/tests/check_util.c
@@ -5,8 +5,8 @@
 #include <string.h>
 #include "irc.h"
 #include "set.h"
-#include "misc.h"
-#include "url.h"
+#include "lib/misc.h"
+#include "lib/url.h"
 
 START_TEST(test_strip_linefeed){
 	int i;

--- a/unix.c
+++ b/unix.c
@@ -25,14 +25,14 @@
 
 #include "bitlbee.h"
 
-#include "arc.h"
-#include "base64.h"
+#include "lib/arc.h"
+#include "lib/base64.h"
 #include "commands.h"
 #include "protocols/nogaim.h"
 #include "help.h"
 #include "ipc.h"
-#include "md5.h"
-#include "misc.h"
+#include "lib/md5.h"
+#include "lib/misc.h"
 #include <signal.h>
 #include <unistd.h>
 #include <sys/time.h>


### PR DESCRIPTION
- Change all header includes to be relative to the project root
- Remove -I${includedir} from bitlbee.pc Cflags
- Install lib and protocols headers to their own directories. So now it is:

```
    /usr/include/bitlbee/*.h
    /usr/include/bitlbee/lib/*.h
    /usr/include/bitlbee/protocols/*.h
```

This breaks backwards compatibility of third party plugins, but now
they don't have to do ambiguous includes like `#include <proxy.h>`

This also fixes trac ticket [#1170][] - conflicts when libproxy and liboauth
are installed at the same time bitlbee is built, which the macports
project ran into several times.

------

Old PR: https://github.com/dequis/bitlbee/pull/57

Trac ticket: [#1170][] - "error: variable has incomplete type 'const struct oauth_service'" - conflict with liboauth in macports (also mentions conflict with libproxy)

Ticket in my personal tracker with @jgeboski asking for this: https://github.com/dequis/bitlbee/issues/21

[#1170]: http://bugs.bitlbee.org/bitlbee/ticket/1170