### PR TITLE
purple: add topic and name_hint to groupchats

### DIFF
--- a/protocols/purple/purple.c
+++ b/protocols/purple/purple.c
@@ -831,8 +831,11 @@ void prplcb_conv_new( PurpleConversation *conv )
 		struct groupchat *gc;
 		
 		gc = imcb_chat_new( ic, conv->name );
-		imcb_chat_name_hint( gc, conv->title );
-		imcb_chat_topic( gc, NULL, conv->title, 0 );
+		if( conv->title != NULL )
+		{
+			imcb_chat_name_hint( gc, conv->title );
+			imcb_chat_topic( gc, NULL, conv->title, 0 );
+		}
 
 		conv->ui_data = gc;
 		gc->data = conv;

--- a/protocols/purple/purple.c
+++ b/protocols/purple/purple.c
@@ -831,6 +831,9 @@ void prplcb_conv_new( PurpleConversation *conv )
 		struct groupchat *gc;
 		
 		gc = imcb_chat_new( ic, conv->name );
+		imcb_chat_name_hint( gc, conv->title );
+		imcb_chat_topic( gc, NULL, conv->title, 0 );
+
 		conv->ui_data = gc;
 		gc->data = conv;
 		


### PR DESCRIPTION
Use imcb_chat_name_hint and imcb_chat_topic for the purple groupchats by using the PurpleConversation 'title' attribute.