### PR TITLE
irc-channel: implemented a special mode for show_users

### DIFF
--- a/irc.c
+++ b/irc.c
@@ -952,11 +952,11 @@ static char *set_eval_bw_compat( set_t *set, char *value )
 	             "channel setting instead.", set->key );
 	
 	if( strcmp( set->key, "away_devoice" ) == 0 && !bool2int( value ) )
-		val = "online,away";
+		val = "online,special%,away";
 	else if( strcmp( set->key, "show_offline" ) == 0 && bool2int( value ) )
-		val = "online@,away+,offline";
+		val = "online@,special%,away+,offline";
 	else
-		val = "online+,away";
+		val = "online+,special%,away";
 	
 	for( l = irc->channels; l; l = l->next )
 	{

--- a/irc.h
+++ b/irc.h
@@ -223,7 +223,7 @@ struct irc_control_channel
 	struct bee_group *group;
 	struct account *account;
 	struct prpl *protocol;
-	char modes[4];
+	char modes[5];
 };
 
 extern const struct bee_ui_funcs irc_ui_funcs;

--- a/irc_channel.c
+++ b/irc_channel.c
@@ -641,13 +641,13 @@ static gboolean control_channel_init( irc_channel_t *ic )
 	set_add( &ic->set, "protocol", NULL, set_eval_by_protocol, ic );
 	
 	/* When changing the default, also change it below. */
-	set_add( &ic->set, "show_users", "online+,away", set_eval_show_users, ic );
+	set_add( &ic->set, "show_users", "online+,special%,away", set_eval_show_users, ic );
 	
 	ic->data = icc = g_new0( struct irc_control_channel, 1 );
 	icc->type = IRC_CC_TYPE_DEFAULT;
 	
 	/* Have to run the evaluator to initialize icc->modes. */
-	set_setstr( &ic->set, "show_users", "online+,away" );
+	set_setstr( &ic->set, "show_users", "online+,special%,away" );
 	
 	/* For scripts that care. */
 	irc_channel_set_mode( ic, "+C" );
@@ -743,9 +743,9 @@ static char *set_eval_show_users( set_t *set, char *value )
 	struct irc_channel *ic = set->data;
 	struct irc_control_channel *icc = ic->data;
 	char **parts = g_strsplit( value, ",", 0 ), **part;
-	char modes[4];
+	char modes[5];
 	
-	memset( modes, 0, 4 );
+	memset( modes, 0, 5 );
 	for( part = parts; *part; part ++ )
 	{
 		char last, modechar = IRC_CHANNEL_USER_NONE;
@@ -765,12 +765,14 @@ static char *set_eval_show_users( set_t *set, char *value )
 			modes[0] = modechar;
 		else if( strncmp( *part, "away", 4 ) == 0 )
 			modes[1] = modechar;
-		else if( strncmp( *part, "online", 6 ) == 0 )
+		else if( strncmp( *part, "special", 7 ) == 0 )
 			modes[2] = modechar;
+		else if( strncmp( *part, "online", 6 ) == 0 )
+			modes[3] = modechar;
 		else
 			goto fail;
 	}
-	memcpy( icc->modes, modes, 4 );
+	memcpy( icc->modes, modes, 5 );
 	bee_irc_channel_update( ic->irc, ic, NULL );
 	
 	g_strfreev( parts );

--- a/irc_im.c
+++ b/irc_im.c
@@ -189,8 +189,10 @@ void bee_irc_channel_update( irc_t *irc, irc_channel_t *ic, irc_user_t *iu )
 			mode = icc->modes[0];
 		else if( iu->bu->flags & BEE_USER_AWAY )
 			mode = icc->modes[1];
-		else
+		else if( iu->bu->flags & BEE_USER_SPECIAL )
 			mode = icc->modes[2];
+		else
+			mode = icc->modes[3];
 		
 		if( !mode )
 			irc_channel_del_user( ic, iu, IRC_CDU_PART, NULL );

--- a/protocols/bee.h
+++ b/protocols/bee.h
@@ -62,6 +62,7 @@ typedef enum
 	BEE_USER_AWAY = 4,      /* Compatibility with old OPT_AWAY flag */
 	BEE_USER_MOBILE = 8,    /* Compatibility with old OPT_MOBILE flag */
 	BEE_USER_LOCAL = 256,   /* Locally-added contacts (not in real contact list) */
+	BEE_USER_SPECIAL = 512, /* Denotes a user as being special */
 } bee_user_flags_t;
 
 typedef struct bee_user


### PR DESCRIPTION
This allows for users to be declared as being special, which does not
have any specific meaning. The meaning of being special is different
from protocol-to-protocol, which many protocols do not even implement.
This functionality is mainly geared towards a special user state which
only some protocols may actually need to define. For example, with the
third-party Steam plugin, this can be used for denoting a user which is
actively playing a game.

By default, this mode will not actually be used by any plugin. However,
it does default to the half-operator user mode.