### PR TITLE
Twitter format strings

### DIFF
--- a/doc/user-guide/commands.xml
+++ b/doc/user-guide/commands.xml
@@ -1083,6 +1083,56 @@
 
 	</bitlbee-setting>
 
+	<bitlbee-setting name="format_string" type="string" scope="account">
+		<default>\002[\002%i\002]\002 %c</default>
+
+		<description>
+			<para>
+				This setting controls how tweets are displayed. Below are listed the two replacement attributes you may use in the string. If you wish to use a percent symbol in your string, ensure you escape it with a second percent symbol (i.e. "%%").
+			</para>
+
+			<variablelist>
+				<varlistentry><term>%i</term><listitem><para>The ID of the tweet</para></listitem></varlistentry>
+				<varlistentry><term>%c</term><listitem><para>The text of the tweet</para></listitem></varlistentry>
+			</variablelist>
+		</description>
+
+	</bitlbee-setting>
+
+	<bitlbee-setting name="reply_format_string" type="string" scope="account">
+		<default>\002[\002%i->%t\002]\002 %c</default>
+
+		<description>
+			<para>
+				This setting controls how replies to tweets are displayed. Below are listed the three replacement attributes you may use in the string. If you wish to use a percent symbol in your string, ensure you escape it with a second percent symbol (i.e. "%%").
+			</para>
+
+			<variablelist>
+				<varlistentry><term>%i</term><listitem><para>The ID of this tweet</para></listitem></varlistentry>
+				<varlistentry><term>%t</term><listitem><para>The ID of the tweet being replied to</para></listitem></varlistentry>
+				<varlistentry><term>%c</term><listitem><para>The text of the tweet</para></listitem></varlistentry>
+			</variablelist>
+		</description>
+
+	</bitlbee-setting>
+
+	<bitlbee-setting name="retweet_format_string" type="string" scope="account">
+		<default>\002[\002%i\002]\002 RT @%a: %c</default>
+
+		<description>
+			<para>
+				This setting controls how retweets are displayed. Below are listed the three replacement attributes you may use in the string. If you wish to use a percent symbol in your string, ensure you escape it with a second percent symbol (i.e. "%%").
+			</para>
+
+			<variablelist>
+				<varlistentry><term>%i</term><listitem><para>The ID of the tweet</para></listitem></varlistentry>
+				<varlistentry><term>%a</term><listitem><para>The author of the original tweet</para></listitem></varlistentry>
+				<varlistentry><term>%c</term><listitem><para>The text of the tweet</para></listitem></varlistentry>
+			</variablelist>
+		</description>
+
+	</bitlbee-setting>
+
 	<bitlbee-setting name="mobile_is_away" type="boolean" scope="global">
 		<default>false</default>
 

--- a/doc/user-guide/commands.xml
+++ b/doc/user-guide/commands.xml
@@ -1084,11 +1084,15 @@
 	</bitlbee-setting>
 
 	<bitlbee-setting name="format_string" type="string" scope="account">
-		<default>\002[\002%i\002]\002 %c</default>
+		<default>^B[^B%i^B]^B %c</default>
 
 		<description>
 			<para>
 				This setting controls how tweets are displayed. Below are listed the two replacement attributes you may use in the string. If you wish to use a percent symbol in your string, ensure you escape it with a second percent symbol (i.e. "%%").
+			</para>
+
+			<para>
+				The default setting contains ^B as a control code for toggling of the bold property. Other similar properties (including color codes) are also functional in this setting. See the documentation for your IRC client for details on such control codes.
 			</para>
 
 			<variablelist>
@@ -1100,11 +1104,15 @@
 	</bitlbee-setting>
 
 	<bitlbee-setting name="reply_format_string" type="string" scope="account">
-		<default>\002[\002%i->%t\002]\002 %c</default>
+		<default>^B[^B%i->%t^B]^B %c</default>
 
 		<description>
 			<para>
 				This setting controls how replies to tweets are displayed. Below are listed the three replacement attributes you may use in the string. If you wish to use a percent symbol in your string, ensure you escape it with a second percent symbol (i.e. "%%").
+			</para>
+
+			<para>
+				The default setting contains ^B as a control code for toggling of the bold property. Other similar properties (including color codes) are also functional in this setting. See the documentation for your IRC client for details on such control codes.
 			</para>
 
 			<variablelist>
@@ -1117,11 +1125,15 @@
 	</bitlbee-setting>
 
 	<bitlbee-setting name="retweet_format_string" type="string" scope="account">
-		<default>\002[\002%i\002]\002 RT @%a: %c</default>
+		<default>^B[^B%i^B]^B RT @%a: %c</default>
 
 		<description>
 			<para>
 				This setting controls how retweets are displayed. Below are listed the three replacement attributes you may use in the string. If you wish to use a percent symbol in your string, ensure you escape it with a second percent symbol (i.e. "%%").
+			</para>
+
+			<para>
+				The default setting contains ^B as a control code for toggling of the bold property. Other similar properties (including color codes) are also functional in this setting. See the documentation for your IRC client for details on such control codes.
 			</para>
 
 			<variablelist>

--- a/doc/user-guide/commands.xml
+++ b/doc/user-guide/commands.xml
@@ -1109,7 +1109,7 @@
 
 			<variablelist>
 				<varlistentry><term>%i</term><listitem><para>The ID of this tweet</para></listitem></varlistentry>
-				<varlistentry><term>%t</term><listitem><para>The ID of the tweet being replied to</para></listitem></varlistentry>
+				<varlistentry><term>%r</term><listitem><para>The ID of the tweet being replied to</para></listitem></varlistentry>
 				<varlistentry><term>%c</term><listitem><para>The text of the tweet</para></listitem></varlistentry>
 			</variablelist>
 		</description>

--- a/protocols/twitter/twitter.c
+++ b/protocols/twitter/twitter.c
@@ -329,6 +329,10 @@ static void twitter_init(account_t * acc)
 	s = set_add(&acc->set, "show_old_mentions", "0", set_eval_int, acc);
 
 	s = set_add(&acc->set, "strip_newlines", "false", set_eval_bool, acc);
+
+	s = set_add(&acc->set, "format_string", "\002[\002%i\002]\002 %c", NULL, acc);
+	s = set_add(&acc->set, "retweet_format_string", "\002[\002%i\002]\002 RT @%a: %c", NULL, acc);
+	s = set_add(&acc->set, "reply_format_string", "\002[\002%i->%t\002]\002 %c", NULL, acc);
 	
 	s = set_add(&acc->set, "_last_tweet", "0", NULL, acc);
 	s->flags |= SET_HIDDEN | SET_NOSAVE;

--- a/protocols/twitter/twitter.c
+++ b/protocols/twitter/twitter.c
@@ -332,7 +332,7 @@ static void twitter_init(account_t * acc)
 
 	s = set_add(&acc->set, "format_string", "\002[\002%i\002]\002 %c", NULL, acc);
 	s = set_add(&acc->set, "retweet_format_string", "\002[\002%i\002]\002 RT @%a: %c", NULL, acc);
-	s = set_add(&acc->set, "reply_format_string", "\002[\002%i->%t\002]\002 %c", NULL, acc);
+	s = set_add(&acc->set, "reply_format_string", "\002[\002%i->%r\002]\002 %c", NULL, acc);
 	
 	s = set_add(&acc->set, "_last_tweet", "0", NULL, acc);
 	s->flags |= SET_HIDDEN | SET_NOSAVE;

--- a/protocols/twitter/twitter_lib.c
+++ b/protocols/twitter/twitter_lib.c
@@ -86,7 +86,7 @@ static void txs_free(struct twitter_xml_status *txs)
 
 	g_free(txs->text);
 	txu_free(txs->user);
-	g_free(txs->rt);
+	txs_free(txs->rt);
 	g_free(txs);
 }
 

--- a/protocols/twitter/twitter_lib.c
+++ b/protocols/twitter/twitter_lib.c
@@ -632,7 +632,7 @@ static char *twitter_msg_get_text(struct im_connection *ic, int log_id, int repl
 				if (reply_to != -1) // In case someone does put %r in the wrong format_string
 				g_string_append_printf(text, "%02x", reply_to);
 				break;
-			case 't':
+			case 'a':
 				if (txs->rt) // In case someone does put %t in the wrong format_string
 					text = g_string_append(text, txs->rt->user->screen_name);
 				break;

--- a/protocols/twitter/twitter_lib.c
+++ b/protocols/twitter/twitter_lib.c
@@ -685,7 +685,7 @@ static char *twitter_msg_add_id(struct im_connection *ic,
 	if (g_strcasecmp(txs->user->screen_name, td->user) == 0)
 		td->log[td->log_id].id = txs->rt_id;
 	
-  return twitter_msg_get_text(ic, td->log_id, reply_to, txs, prefix);
+	return twitter_msg_get_text(ic, td->log_id, reply_to, txs, prefix);
 }
 
 /**

--- a/protocols/twitter/twitter_lib.c
+++ b/protocols/twitter/twitter_lib.c
@@ -633,7 +633,7 @@ static char *twitter_msg_get_text(struct im_connection *ic, int log_id, int repl
 				g_string_append_printf(text, "%02x", reply_to);
 				break;
 			case 'a':
-				if (txs->rt) // In case someone does put %t in the wrong format_string
+				if (txs->rt) // In case someone does put %a in the wrong format_string
 					text = g_string_append(text, txs->rt->user->screen_name);
 				break;
 			case 'c':


### PR DESCRIPTION
Allow users to specify how tweets should be displayed

3 new settings are available to set how tweets are displayed:
 - twitter_format_string for normal tweets
 - retweet_format_string for retweets
 - reply_format_string for replies

For full documentation see the help files