### PR TITLE
Add raw reply support

### DIFF
--- a/doc/user-guide/commands.xml
+++ b/doc/user-guide/commands.xml
@@ -846,6 +846,7 @@
 				<varlistentry><term>undo #[&lt;id&gt;]</term><listitem><para>Delete your last Tweet (or one with the given ID)</para></listitem></varlistentry>
 				<varlistentry><term>rt &lt;screenname|#id&gt;</term><listitem><para>Retweet someone's last Tweet (or one with the given ID)</para></listitem></varlistentry>
 				<varlistentry><term>reply &lt;screenname|#id&gt;</term><listitem><para>Reply to a Tweet (with a reply-to reference)</para></listitem></varlistentry>
+				<varlistentry><term>rawreply &lt;screenname|#id&gt;</term><listitem><para>Reply to a Tweet (with no reply-to reference)</para></listitem></varlistentry>
 				<varlistentry><term>report &lt;screenname|#id&gt;</term><listitem><para>Report the given user (or the user who posted the tweet with the given ID) for sending spam. This will also block them.</para></listitem></varlistentry>
 				<varlistentry><term>follow &lt;screenname&gt;</term><listitem><para>Start following a person</para></listitem></varlistentry>
 				<varlistentry><term>unfollow &lt;screenname&gt;</term><listitem><para>Stop following a person</para></listitem></varlistentry>

--- a/protocols/twitter/twitter.c
+++ b/protocols/twitter/twitter.c
@@ -673,6 +673,15 @@ static void twitter_handle_command(struct im_connection *ic, char *message)
 		message = new = g_strdup_printf("@%s %s", bu->handle, cmd[2]);
 		in_reply_to = id;
 		allow_post = TRUE;
+	} else if (g_strcasecmp(cmd[0], "rawreply") == 0 && cmd[1] && cmd[2]) {
+		id = twitter_message_id_from_command_arg(ic, cmd[1], NULL);
+		if (!id) {
+			twitter_log(ic, "Tweet `%s' does not exist", cmd[1]);
+			goto eof;
+		}
+		message += (cmd[2] - cmd[0]);
+		in_reply_to = id;
+		allow_post = TRUE;
 	} else if (g_strcasecmp(cmd[0], "post") == 0) {
 		message += 5;
 		allow_post = TRUE;

--- a/protocols/twitter/twitter.c
+++ b/protocols/twitter/twitter.c
@@ -679,7 +679,7 @@ static void twitter_handle_command(struct im_connection *ic, char *message)
 			twitter_log(ic, "Tweet `%s' does not exist", cmd[1]);
 			goto eof;
 		}
-		message += (cmd[2] - cmd[0]);
+		message = cmd[2];
 		in_reply_to = id;
 		allow_post = TRUE;
 	} else if (g_strcasecmp(cmd[0], "post") == 0) {


### PR DESCRIPTION
By default, "reply" prepends the username of the tweet being replied to. This
adds support for a "rawreply" command which does not prepend this username.
This is useful for "replying" to your own tweet to maintain a chain of tweets
on a singular topic.