### PR TITLE
Refactor oauth_params_del to fix use-after-free that i introduced

### DIFF
--- a/lib/oauth.c
+++ b/lib/oauth.c
@@ -95,19 +95,18 @@ void oauth_params_add(GSList **params, const char *key, const char *value)
 void oauth_params_del(GSList **params, const char *key)
 {
 	int key_len = strlen(key);
-	GSList *l, *n;
+	GSList *l;
 
-	if (params == NULL) {
+	if (!params) {
 		return;
 	}
 
-	for (l = *params; l; l = n) {
-		n = l->next;
+	for (l = *params; l; l = l->next) {
+		char *data = l->data;
 
-		if (strncmp((char *) l->data, key, key_len) == 0 &&
-		    ((char *) l->data)[key_len] == '=') {
-			*params = g_slist_remove(*params, l->data);
-			g_free(l->data);
+		if (strncmp(data, key, key_len) == 0 && data[key_len] == '=') {
+			*params = g_slist_remove(*params, data);
+			g_free(data);
 		}
 	}
 }


### PR DESCRIPTION
Yeah ok that was dumb.

This is essentially just using a `data` variable instead of `l->data`, but i went ahead and cleaned up the function.