### PR TITLE
help: Increase read buffer size from 1100 to 2048

### DIFF
--- a/help.c
+++ b/help.c
@@ -29,7 +29,7 @@
 #undef read
 #undef write
 
-#define BUFSIZE 1100
+#define BUFSIZE 2048
 
 help_t *help_init(help_t **help, const char *helpfile)
 {


### PR DESCRIPTION
This fixes "Error opening helpfile." that was introduced by the rawreply commit, which made the help string for "help set commands" larger than 1100 bytes, making the strstr(s, "\n%\n") condition fail

I have absolutely no idea why it was 1100 to begin with. It's been like that since the first revision. 4096 is arbitrary too, but it's nicer.

Needless to say, the help.c code needs to be reviewed more deeply, at least. Could also use that opportunity to get rid of the xmlto/xslt crap. Not going to do that right now, i don't want to add more bugs.

-------

PRing mostly to see what wilmer says, but I think asking for the reason of a magic number that hasn't been touched in 10+ years would be too much.