### PR TITLE
Various user experience/error reporting improvements

### DIFF
--- a/irc.c
+++ b/irc.c
@@ -763,11 +763,13 @@ int irc_check_login(irc_t *irc)
 
 			irc_rootmsg(irc,
 			            "Welcome to the BitlBee gateway!\n\n"
+			            "Running %s %s\n\n"
 			            "If you've never used BitlBee before, please do read the help "
 			            "information using the \x02help\x02 command. Lots of FAQs are "
 			            "answered there.\n"
 			            "If you already have an account on this server, just use the "
-			            "\x02identify\x02 command to identify yourself.");
+			            "\x02identify\x02 command to identify yourself.",
+			            PACKAGE, BITLBEE_VERSION);
 
 			/* This is for bug #209 (use PASS to identify to NickServ). */
 			if (irc->password != NULL) {

--- a/protocols/twitter/twitter_lib.c
+++ b/protocols/twitter/twitter_lib.c
@@ -861,6 +861,9 @@ static void twitter_http_stream(struct http_request *req)
 		}
 
 		imcb_error(ic, "Stream closed (%s)", req->status_string);
+		if (req->status_code == 401) {
+			imcb_error(ic, "Check your system clock.");
+		}
 		imc_logout(ic, TRUE);
 		return;
 	}


### PR DESCRIPTION
- Show version as part of the initial message of &bitlbee
- Use `g_strerror()` to show actual errors when saving xml configs
- Only show `The nick is (probably) not registered` for ENOENT, use
  `g_strerror()` for the rest of OS errors when loading xml configs
- Show `Protocol not found: <name>` when `find_protocol()` returns null,
  useful when the user uninstalls a plugin accidentally.
- Suggest the user to check the system clock when getting error 401 from
  the twitter stream (other REST endpoints show a better error message)

-----

I don't know what a "feature freeze" is.

Either way I wanted to do this for a long while.

------

Before: (with a config file that has whatsapp, meant to be used with libpurple)

```
23:59 <@root> Welcome to the BitlBee gateway!
23:59 <@root>
23:59 <@root> If you've never used BitlBee before, please do read the help information using the help command. Lots of FAQs are answered there.
23:59 <@root> If you already have an account on this server, just use the identify command to identify yourself.
23:59 <@root> Unknown error while loading configuration
```

After:

```
23:59 <@root> Welcome to the BitlBee gateway!
23:59 <@root>
23:59 <@root> Running BitlBee 3.2.2-1-103-ge6f47fb-develop-git
23:59 <@root>
23:59 <@root> If you've never used BitlBee before, please do read the help information using the help command. Lots of FAQs are answered there.
23:59 <@root> If you already have an account on this server, just use the identify command to identify yourself.
23:59 <@root> Error loading user config: Protocol not found: `whatsapp'
23:59 <@root> Unknown error while loading configuration
```

And now the error should be obvious for most people!

------

*Regarding "Unknown error while loading configuration" above* - It still says that because that's the catch-all - i'm not going to redesign storage error reporting right now, i'm just doing `irc_rootmsg()` from there (which was already done in other functions of the same file)

*Regarding the version string* - Showing it there should help with those cases of "did you really kill the old bitlbee" or "are you sure you're running the right one" and i might need to tell people to do `/ctcp root version` less often, maybe. And yes, this is the same version string shown in the numeric 002, but nobody reads the initial flood of server messages.

*Regarding the paranoid mode plans*  - A long time ago wilmer said these errors are somewhat intentinally vague because revealing too much information in public servers might be undesirable. So there was the idea of having a "paranoid" mode toggleable in the global config, which hides information like that from irc users but still logs somewhere else. I decided to avoid doing that for now and went for a compromise - `g_strerror()` should be helpful enough for debugging config loading/saving errors and is highly unlikely to reveal anything of interest.

*Regarding the twitter error message* - like i said above, the REST endpoints provide a better error mesage. It's not great but it points in the right direction. This is what you get when the system clock is a few hours in the **past**:

```
00:31 <@root> twitter - Logging in: Getting contact list
00:31 <@root> twitter - Login error: Authentication failure (401 Authorization Required (Timestamp out of bounds.))
```

And when the system clock is a few hours in the **future**, the REST endpoints don't fail, but the stream does, and this is what this commit tries to improve, since the 401 reply doesn't include more details:

```
06:33 <@root> twitter - Logging in: Logged in
06:33 <@root> twitter - Error: Stream closed (401 Authorization Required)
06:33 <@root> twitter - Error: If you keep getting this, try checking your system clock
```

The actual threshold is around 5 minutes, which is why people without NTP and with a bad hardware clock often get this suddenly and don't know why.

------

Already tested. Not a lot to review here, just looking for general opinions.

I accidentally wrote too much again.