### PR TITLE
chat_name_hint: normalize utf8 with fallback from the channel name

### DIFF
--- a/irc_im.c
+++ b/irc_im.c
@@ -694,7 +694,8 @@ static gboolean bee_irc_chat_name_hint(bee_t *bee, struct groupchat *c, const ch
 {
 	irc_t *irc = bee->ui_data;
 	irc_channel_t *ic = c->ui_data, *oic;
-	char stripped[MAX_NICK_LENGTH + 1], *full_name;
+	char *stripped, *full_name;
+	gsize bytes_written;
 
 	if (ic == NULL) {
 		return FALSE;
@@ -705,18 +706,23 @@ static gboolean bee_irc_chat_name_hint(bee_t *bee, struct groupchat *c, const ch
 		return FALSE;
 	}
 
-	strncpy(stripped, name, MAX_NICK_LENGTH);
-	stripped[MAX_NICK_LENGTH] = '\0';
+	stripped = g_convert_with_fallback(name, -1, "ASCII//TRANSLIT",
+	        "UTF-8", "", NULL, &bytes_written, NULL);
+	if (bytes_written > MAX_NICK_LENGTH)
+		stripped[MAX_NICK_LENGTH] = '\0';
+
 	irc_channel_name_strip(stripped);
 	if (set_getbool(&bee->set, "lcnicks")) {
 		nick_lc(irc, stripped);
 	}
 
 	if (stripped[0] == '\0') {
+		g_free(stripped);
 		return FALSE;
 	}
 
 	full_name = g_strdup_printf("#%s", stripped);
+	g_free(stripped);
 	if ((oic = irc_channel_by_name(irc, full_name))) {
 		char *type, *chat_type;
 


### PR DESCRIPTION
When using chat_name_hint(), normalize utf8 names with a fallback to ascii (it was already done that way for nicks.)
Example: #Voilà → #Voila

Tested with valgrind.
We could also add utf8 support for channels if utf8_nicks is enabled, but this change would be more complex.