### PR TITLE
Prepare for 3.4 release (changelogs and stuff)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ tar:
 	fakeroot debian/rules clean || make distclean
 	x=$$(basename $$(pwd)); \
 	cd ..; \
-	tar czf $$x.tar.gz --exclude-from=.gitignore $$x
+	tar czf $$x.tar.gz --exclude=debian --exclude=.git* --exclude=.depend $$x
 
 $(subdirs):
 	@$(MAKE) -C $@ $(MAKECMDGOALS)

--- a/bitlbee.h
+++ b/bitlbee.h
@@ -35,10 +35,10 @@ extern "C" {
 #endif
 
 #define PACKAGE "BitlBee"
-#define BITLBEE_VERSION "3.2.2"
+#define BITLBEE_VERSION "3.4"
 #define VERSION BITLBEE_VERSION
 #define BITLBEE_VER(a, b, c) (((a) << 16) + ((b) << 8) + (c))
-#define BITLBEE_VERSION_CODE BITLBEE_VER(3, 2, 2)
+#define BITLBEE_VERSION_CODE BITLBEE_VER(3, 4, 0)
 
 #define MAX_STRING 511
 

--- a/doc/CHANGES
+++ b/doc/CHANGES
@@ -1,7 +1,48 @@
 This ChangeLog mostly lists changes relevant to users. A full log can be
-found in the bzr commit logs, for example you can try:
+found in the git commit logs, for example you can try:
 
-http://bugs.bitlbee.org/bitlbee/timeline?daysback=90&changeset=on
+https://github.com/bitlbee/bitlbee/commits/master
+
+Version 3.4:
+- Main repository migrated from bzr to git
+- Some API/ABI changes. Recompiling third party plugins is required!
+- Important bugfixes:
+  * Fix memory leak when calling word_wrap() on groupchat messages (dx)
+  * Fix segfault after a file transfer is complete (dx)
+  * Fix bug where NSS would refuse to work in forkdaemon mode (dx)
+  * Fix several bugs with UTF8 nicks (dx)
+  * Fix some nasty deadlocks that appared mostly with libpurple (dx)
+- General changes:
+  * Add a 'pattern' parameter to the blist command, to filter it (tribut)
+  * Implemented /kick support, only supported by purple for now (jgeboski)
+  * Add a "special" state to show_users (mapped to the % prefix) (jgeboski)
+  * Improved support for cygwin, openbsd and darwin (jcopenha)
+  * Create temporary users instead of showing "Message from unknown
+    participant" (jgeboski)
+- purple:
+  * Local contact lists for gadugadu and whatsapp (dx)
+  * Add topic and name_hint to groupchats (seirl)
+  * Support for 'input' requests (such as telegram auth codes) (seirl)
+    Note that telegram-purple itself is rather unstable ATM, it may crash.
+- jabber:
+  * Handle compressed DNS responses in SRV lookup (jcopenha)
+  * Fix case sensitivity issues with JIDs (GRMrGecko, dx)
+  * Implement XEP-0203 style message timestamps (dx)
+  * Fix "Server claims your JID is X instead of Y" warnings (dx)
+  * Account-wide display_name setting, mostly for hipchat (dx)
+- twitter:
+  * Filter channels. Search by keyword/hashtag or a list of users (jgeboski)
+  * Fix bug in "reply" command which removed the first quote character (dx)
+  * Add "rawreply" command, like reply but bitlbee won't add @mention (WillP)
+  * Add support for The United States of America (favorite/fav aliases) (dx)
+  * Default show_old_mentions to 0 (dx)
+  * Start stream from last tweet on connect/reconnect (roger)
+- msn:
+  * Disabled module by default. The protocol we used (MSNP18) stopped working
+    last week. This is being worked on, but it's far from ready for release.
+- And lots of small bugfixes, too many to list here.
+
+Finished ... 20XX
 
 Version 3.2.2:
 - The OTR plugin now uses libotr 4.0 (AKA libotr5 in debian based distros)

--- a/doc/CHANGES
+++ b/doc/CHANGES
@@ -4,6 +4,8 @@ found in the git commit logs, for example you can try:
 https://github.com/bitlbee/bitlbee/commits/master
 
 Version 3.4:
+- First release pretty much fully prepared by dx instead of Wilmer. Just look
+  at the tightly structured changelog!
 - Main repository migrated from bzr to git
 - Some API/ABI changes. Recompiling third party plugins is required!
 - Important bugfixes:
@@ -42,7 +44,7 @@ Version 3.4:
     last week. This is being worked on, but it's far from ready for release.
 - And lots of small bugfixes, too many to list here.
 
-Finished ... 20XX
+Finished 25 Mar 2015
 
 Version 3.2.2:
 - The OTR plugin now uses libotr 4.0 (AKA libotr5 in debian based distros)

--- a/doc/user-guide/misc.xml
+++ b/doc/user-guide/misc.xml
@@ -408,4 +408,28 @@ passwords with <emphasis>account tag set -del password</emphasis>
 </para>
 </sect1>
 
+<sect1 id="whatsnew030400">
+<title>New stuff in BitlBee 3.4</title>
+
+<para>
+Lots of bugfixes! <emphasis>Important:</emphasis> Recompiling third party plugins such as bitlbee-steam or bitlbee-facebook is <emphasis>required</emphasis>!
+</para>
+
+<simplelist>
+	<member><emphasis>twitter:</emphasis> Filter channels - Search by keyword/hashtag or a list of users. See the <emphasis>HowtoTwitter</emphasis> wiki page for more details!</member>
+	<member><emphasis>twitter:</emphasis> Add "rawreply" command, like reply but bitlbee won't add @mention. Also add "favorite" / "fav" command aliases.</member>
+	<member><emphasis>twitter:</emphasis> Start stream from last tweet on connect/reconnect to avoid showing duplicate tweets</member>
+	<member><emphasis>jabber:</emphasis> Fixed crashes with file transfers (they still fail at bypassing NATs, but at least they fail without crashing)</member>
+	<member><emphasis>purple:</emphasis> Improved support for gadugadu, whatsapp and telegram.</member>
+	<member><emphasis>msn:</emphasis> disabled in this release since the protocol we used (MSNP18) stopped working.</member>
+	<member>Add a 'pattern' parameter to the blist command, to filter it.</member>
+	<member>The <emphasis>utf8_nicks</emphasis> setting should be more reliable now.</member>
+</simplelist>
+
+<para>
+See the full changelog for details!
+</para>
+
+</sect1>
+
 </chapter>


### PR DESCRIPTION
Copying checklist from https://wiki.bitlbee.org/ReleaseChecklist

Code:

- [x] ./bitlbee.h, `#define BITLBEE_VERSION "3.2.2"`, `#define BITLBEE_VERSION_CODE BITLBEE_VER(3, 2, 2)`
- [x] ./doc/CHANGES
- [x] ./doc/user-guide/misc.xml, `<sect1 id="whatsnew030202">...</sect1>`

Website:

- [x] ./bitlbee.data
- [x] ./html/changelog.html
    - ~~This one is rather redundant, i'm tempted to nuke it and redirect to some hosted version of ./doc/CHANGES~~ used pandoc to have doc/CHANGES as the source.
- [x] ./maint/news.txt 

Other stuff:

- [ ] announce on twitter
- [x] remind people to recompile third party plugins to minimize broken abi related reports
- [ ] poke distros

debian:
- build debian packages
    - Debian testing is frozen, not worth bothering about releasing packages there *right now*
- ./debian/changelog

Wilmer's part (afaik)
- [x] merge website repo
- [x] merge this
- [x] Set final date in ./doc/CHANGES
- [x] Set final date in news.txt
- [x] Update changelog.html to use final date from new doc/CHANGES
- [x] git tag
- [x] tarball