### PR TITLE
jabber: Register "hipchat" protocol (only minimal support for now)

### DIFF
--- a/protocols/jabber/jabber.h
+++ b/protocols/jabber/jabber.h
@@ -47,6 +47,7 @@ typedef enum {
 	JFLAG_STARTTLS_DONE = 128,      /* If a plaintext session was converted to TLS. */
 
 	JFLAG_GTALK =  0x100000,        /* Is Google Talk, as confirmed by iq discovery */
+	JFLAG_HIPCHAT = 0x200000,       /* Is hipchat, because prpl->name says so */
 
 	JFLAG_SASL_FB = 0x10000,        /* Trying Facebook authentication. */
 } jabber_flags_t;


### PR DESCRIPTION
Another take on [the subprotocols idea][1] that, IMO, was a failure.

Unlike the other implementation, this one doesn't touch gtalk/facebook accounts, it just adds another copy of the "jabber" prpl called "hipchat".

And, based on the protocol name:

- sets JFLAG_HIPCHAT to jabber_data
- sets the default value of the "server" setting
- only includes the oauth setting for jabber-type accounts

This is slightly more "hardcoded" but honestly facebook and gtalk are just as hardcoded as this.

Copying the prpl is needed because the meaning of the usernames is completely different (there's no srv lookup stuff either)

[1]: https://github.com/bitlbee/bitlbee/commit/7733b8c95abbac26f5cbf02a9874a9d96c23bf0d