### PR TITLE
hipchat: Basic implementation: Auth, profile and mention names

### DIFF
--- a/protocols/jabber/Makefile
+++ b/protocols/jabber/Makefile
@@ -12,7 +12,7 @@ _SRCDIR_ := $(_SRCDIR_)protocols/jabber/
 endif
 
 # [SH] Program variables
-objects = conference.o io.o iq.o jabber.o jabber_util.o message.o presence.o s5bytestream.o sasl.o si.o
+objects = conference.o io.o iq.o jabber.o jabber_util.o message.o presence.o s5bytestream.o sasl.o si.o hipchat.o
 
 LFLAGS += -r
 

--- a/protocols/jabber/hipchat.c
+++ b/protocols/jabber/hipchat.c
@@ -1,0 +1,93 @@
+/***************************************************************************\
+*                                                                           *
+*  BitlBee - An IRC to IM gateway                                           *
+*  Jabber module - HipChat specific functions                               *
+*                                                                           *
+*  Copyright 2015 Xamarin Inc                                               *
+*                                                                           *
+*  This program is free software; you can redistribute it and/or modify     *
+*  it under the terms of the GNU General Public License as published by     *
+*  the Free Software Foundation; either version 2 of the License, or        *
+*  (at your option) any later version.                                      *
+*                                                                           *
+*  This program is distributed in the hope that it will be useful,          *
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of           *
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+*  GNU General Public License for more details.                             *
+*                                                                           *
+*  You should have received a copy of the GNU General Public License along  *
+*  with this program; if not, write to the Free Software Foundation, Inc.,  *
+*  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.              *
+*                                                                           *
+\***************************************************************************/
+
+#include "jabber.h"
+
+xt_status hipchat_handle_success(struct im_connection *ic, struct xt_node *node)
+{
+	struct jabber_data *jd = ic->proto_data;
+	char *sep, *jid;
+
+	jid = xt_find_attr(node, "jid");
+
+	sep = strchr(jid, '/');
+	if (sep) {
+		*sep = '\0';
+	}
+
+	jabber_set_me(ic, jid);
+	imcb_log(ic, "Setting Hipchat JID to %s", jid);
+
+	if (sep) {
+		*sep = '/';
+	}
+
+	/* Hipchat's auth doesn't expect a restart here */
+	jd->flags &= ~JFLAG_STREAM_RESTART;
+
+	if (!jabber_get_roster(ic) ||
+	    !jabber_iq_disco_server(ic) ||
+	    !jabber_get_hipchat_profile(ic)) {
+		return XT_ABORT;
+	}
+
+	return XT_HANDLED;
+}
+
+int jabber_get_hipchat_profile(struct im_connection *ic)
+{
+	struct jabber_data *jd = ic->proto_data;
+	struct xt_node *node;
+	int st;
+
+	imcb_log(ic, "Fetching hipchat profile for %s", jd->me);
+
+	node = xt_new_node("query", NULL, NULL);
+	xt_add_attr(node, "xmlns", XMLNS_HIPCHAT_PROFILE);
+	node = jabber_make_packet("iq", "get", jd->me, node);
+
+	jabber_cache_add(ic, node, jabber_parse_hipchat_profile);
+	st = jabber_write_packet(ic, node);
+
+	return st;
+}
+
+xt_status jabber_parse_hipchat_profile(struct im_connection *ic, struct xt_node *node, struct xt_node *orig)
+{
+	struct xt_node *query, *name_node;
+
+	if (!(query = xt_find_node(node->children, "query"))) {
+		imcb_log(ic, "Warning: Received NULL profile packet");
+		return XT_ABORT;
+	}
+
+	name_node = xt_find_node(query->children, "name");
+	if (!name_node) {
+		imcb_log(ic, "Warning: Can't find real name in profile. Joining groupchats will not be possible.");
+		return XT_ABORT;
+	}
+
+	set_setstr(&ic->acc->set, "display_name", name_node->text);
+	return XT_HANDLED;
+
+}

--- a/protocols/jabber/jabber.h
+++ b/protocols/jabber/jabber.h
@@ -235,6 +235,10 @@ struct jabber_transfer {
 #define XMLNS_BYTESTREAMS  "http://jabber.org/protocol/bytestreams"              /* XEP-0065 */
 #define XMLNS_IBB          "http://jabber.org/protocol/ibb"                      /* XEP-0047 */
 
+/* Hipchat protocol extensions*/
+#define XMLNS_HIPCHAT         "http://hipchat.com"
+#define XMLNS_HIPCHAT_PROFILE "http://hipchat.com/protocol/profile"
+
 /* jabber.c */
 void jabber_connect(struct im_connection *ic);
 
@@ -249,6 +253,7 @@ int jabber_remove_from_roster(struct im_connection *ic, char *handle);
 xt_status jabber_iq_query_features(struct im_connection *ic, char *bare_jid);
 xt_status jabber_iq_query_server(struct im_connection *ic, char *jid, char *xmlns);
 void jabber_iq_version_send(struct im_connection *ic, struct jabber_buddy *bud, void *data);
+int jabber_iq_disco_server(struct im_connection *ic);
 
 /* si.c */
 int jabber_si_handle_request(struct im_connection *ic, struct xt_node *node, struct xt_node *sinode);
@@ -340,5 +345,10 @@ int jabber_chat_leave(struct groupchat *c, const char *reason);
 void jabber_chat_pkt_presence(struct im_connection *ic, struct jabber_buddy *bud, struct xt_node *node);
 void jabber_chat_pkt_message(struct im_connection *ic, struct jabber_buddy *bud, struct xt_node *node);
 void jabber_chat_invite(struct groupchat *c, char *who, char *message);
+
+/* hipchat.c */
+int jabber_get_hipchat_profile(struct im_connection *ic);
+xt_status jabber_parse_hipchat_profile(struct im_connection *ic, struct xt_node *node, struct xt_node *orig);
+xt_status hipchat_handle_success(struct im_connection *ic, struct xt_node *node);
 
 #endif


### PR DESCRIPTION
This is enough to log in with their usernames, make 'chat add' based groupchat joins slightly more smooth, and see mention names as nicks.

All the MUC list stuff is left out intentionally since that's not as stable as I wish.

-----------

I said I was going to just push this thing, but it turned out to be short enough

The next PR is probably going to be 59c1fe7fce52811f6cd99345373bee26a478c27b which is mostly a major rewrite of jabber_chat_pkt_message that benefits normal jabber MUCs too