### PR TITLE
jabber: Refactor conference message handling

### DIFF
--- a/protocols/jabber/jabber.h
+++ b/protocols/jabber/jabber.h
@@ -311,6 +311,7 @@ time_t jabber_get_timestamp(struct xt_node *xt);
 struct jabber_error *jabber_error_parse(struct xt_node *node, char *xmlns);
 void jabber_error_free(struct jabber_error *err);
 gboolean jabber_set_me(struct im_connection *ic, const char *me);
+char *jabber_get_bare_jid(char *jid);
 
 extern const struct jabber_away_state jabber_away_state_list[];
 

--- a/protocols/jabber/jabber_util.c
+++ b/protocols/jabber/jabber_util.c
@@ -819,3 +819,19 @@ gboolean jabber_set_me(struct im_connection *ic, const char *me)
 
 	return TRUE;
 }
+
+/* Returns new reference! g_free() afterwards. */
+char *jabber_get_bare_jid(char *jid)
+{
+	char *s = NULL;
+
+	if (jid == NULL) {
+		return NULL;
+	}
+
+	if ((s = strchr(jid, '/'))) {
+		return g_strndup(jid, s - jid);
+	} else {
+		return g_strdup(jid);
+	}
+}


### PR DESCRIPTION
- Improve handling of "unknown 'from'"
- Try a bit harder to detect the source of the message, and fall back to
  messages sent from a fake temporary user.
- Fix receiving topic when it was set by someone who left the room.
- Add jabber_get_bare_jid() utility function

-------

Cherry-picked from the hipchat branch (only fixed conflicts and changed commit message), so tested quite a lot there. It improves things.