### PR TITLE
Add python script to generate help.txt, replacing xslt stuff

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ script:
 
 before_install:
  - sudo apt-get update -qq
- - sudo apt-get install --no-install-recommends -qq asciidoc xsltproc xmlto lynx check libevent-dev libpurple-dev check
+ - sudo apt-get install --no-install-recommends -qq asciidoc libevent-dev libpurple-dev check
  - wget http://dump.dequis.org/indexed/bitlbee-travis-libs/libotr5{,-dev}_4.1.0-2~bpo70+1_amd64.deb
  - sudo dpkg -i *.deb
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ script:
 
 before_install:
  - sudo apt-get update -qq
- - sudo apt-get install --no-install-recommends -qq asciidoc libevent-dev libpurple-dev check
+ - sudo apt-get install --no-install-recommends -qq libevent-dev libpurple-dev check
  - wget http://dump.dequis.org/indexed/bitlbee-travis-libs/libotr5{,-dev}_4.1.0-2~bpo70+1_amd64.deb
  - sudo dpkg -i *.deb
 

--- a/configure
+++ b/configure
@@ -687,16 +687,6 @@ if [ "$doc" = "1" ]; then
 		exit 1
 	fi
 	echo "DOC=1" >> Makefile.settings
-
-	if [ "$skype" = "1" -o "$skype" = "plugin" ]; then
-		# skype also needs asciidoc
-		if ! type a2x > /dev/null 2> /dev/null; then
-			echo
-			echo 'WARNING: The skyped man page requires asciidoc. It will not be generated.'
-		else
-			echo "ASCIIDOC=1" >> Makefile.settings
-		fi
-	fi
 fi
 
 get_version

--- a/configure
+++ b/configure
@@ -680,16 +680,13 @@ if [ "$skype" = "1" -o "$skype" = "plugin" ]; then
 fi
 
 if [ "$doc" = "1" ]; then
-	if [ ! -e doc/user-guide/help.txt ] && \
-	     ! type xmlto > /dev/null 2> /dev/null || \
-	     ! type xsltproc > /dev/null 2> /dev/null
-	then
+	# check this here just in case someone tries to install it in python2.4...
+	if ! python -m xml.etree.ElementTree > /dev/null 2>&1; then
 		echo
-		echo 'WARNING: Building from an unreleased source tree without prebuilt helpfile.'
-		echo 'Install xmlto and xsltproc if you want online help to work.'
-	else
-		echo "DOC=1" >> Makefile.settings
+		echo 'ERROR: Python (>=2.5 or 3.x) is required to generate docs'
+		exit 1
 	fi
+	echo "DOC=1" >> Makefile.settings
 
 	if [ "$skype" = "1" -o "$skype" = "plugin" ]; then
 		# skype also needs asciidoc

--- a/debian/bitlbee-common.docs
+++ b/debian/bitlbee-common.docs
@@ -1,5 +1,3 @@
-doc/user-guide/user-guide.txt
-doc/user-guide/user-guide.html
 doc/AUTHORS
 doc/CREDITS
 doc/FAQ

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Wilmer van der Gaast <wilmer@gaast.net>
 Uploaders: Jelmer Vernooij <jelmer@debian.org>
 Standards-Version: 3.9.5
-Build-Depends: libglib2.0-dev (>= 2.4), libevent-dev, libgnutls28-dev | libgnutls-dev | gnutls-dev, po-debconf, libpurple-dev, libotr5-dev, debhelper (>= 6.0.7~), asciidoc
+Build-Depends: libglib2.0-dev (>= 2.4), libevent-dev, libgnutls28-dev | libgnutls-dev | gnutls-dev, po-debconf, libpurple-dev, libotr5-dev, debhelper (>= 6.0.7~)
 Homepage: http://www.bitlbee.org/
 Vcs-Bzr: http://code.bitlbee.org/bitlbee/
 

--- a/doc/user-guide/Makefile
+++ b/doc/user-guide/Makefile
@@ -3,10 +3,9 @@ ifdef _SRCDIR_
 _SRCDIR_ := $(_SRCDIR_)doc/user-guide/
 endif
 
-EXTRAPARANEWLINE = 1
-# EXTRAPARANEWLINE = 0
+all: help.txt
 
-all: user-guide.txt user-guide.html help.txt # user-guide.pdf user-guide.ps user-guide.rtf
+user-guide: user-guide.txt user-guide.html # user-guide.pdf user-guide.ps user-guide.rtf
 
 %.tex: %.db.xml
 	xsltproc --stringparam l10n.gentext.default.language "en" --stringparam latex.documentclass.common "" --stringparam latex.babel.language "" --output $@ http://db2latex.sourceforge.net/xsl/docbook.xsl $<
@@ -32,7 +31,7 @@ help.xml: commands.xml
 	xsltproc --xinclude --output $@ docbook.xsl $< 
 
 help.txt: help.xml help.xsl commands.xml misc.xml quickstart.xml
-	xsltproc --stringparam extraparanewline "$(EXTRAPARANEWLINE)" --xinclude help.xsl $< | perl -0077 -pe 's/\n\n%/\n%/s; s/_b_/\002/g;' > $@
+	python genhelp.py $< $@
 
 clean: 
 	rm -f *.html *.pdf *.ps *.rtf *.txt *.db.xml
@@ -47,4 +46,4 @@ uninstall:
 	rm -f $(DESTDIR)$(DATADIR)/help.txt
 	-rmdir $(DESTDIR)$(DATADIR)
 
-.PHONY: clean install uninstall
+.PHONY: clean install uninstall user-guide

--- a/doc/user-guide/genhelp.py
+++ b/doc/user-guide/genhelp.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
-#
+
+# Usage: python genhelp.py input.xml output.txt
+# (Both python2 (>=2.5) or python3 work)
+
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
 # as published by the Free Software Foundation; either version 2
@@ -17,10 +20,9 @@
 
 
 import re
+import sys
 import xml.etree.ElementTree as ET
 
-IN_FILE = 'help.xml'
-OUT_FILE = 'help.txt'
 NORMALIZE_RE = re.compile(r"([^<>\s\t])[\s\t]+([^<>\s\t])")
 
 # Helpers
@@ -215,8 +217,12 @@ def tag_simplelist(tag, parent):
 
 
 def main():
-    txt = process_file(IN_FILE)
-    open(OUT_FILE, "w").write(txt)
+    if len(sys.argv) != 3:
+        print("Usage: python genhelp.py input.xml output.txt")
+        return
+
+    txt = process_file(sys.argv[1])
+    open(sys.argv[2], "w").write(txt)
 
 if __name__ == '__main__':
     main()

--- a/doc/user-guide/genhelp.py
+++ b/doc/user-guide/genhelp.py
@@ -1,0 +1,165 @@
+import re
+import xml.etree.ElementTree as ET
+
+IN_FILE = 'help.xml'
+OUT_FILE = 'help.txt'
+NORMALIZE_RE = re.compile(r"([^<>\s\t])[\s\t]+([^<>\s\t])")
+
+def join(list):
+    return ''.join([str(x) for x in list])
+
+def normalize(x):
+    x = NORMALIZE_RE.sub(r"\1 \2", x or '')
+    return x.replace("\n", "").replace("\t", "")
+
+def fix_tree(tag, lvl=''):
+    if tag.tag.count("XInclude"):
+        tag.tag = 'include'
+
+    #print("%s<%s>%r" % (lvl, tag.tag, [tag.text, normalize(tag.text)]))
+
+    for subtag in tag:
+        fix_tree(subtag, lvl + "  ")
+
+    #print("%s</%s>%r" % (lvl, tag.tag, [tag.tail, normalize(tag.tail)]))
+
+    tag.text = normalize(tag.text)
+    tag.tail = normalize(tag.tail)
+
+def parse_file(filename, parent=None):
+    tree = ET.parse(open(filename)).getroot()
+    fix_tree(tree)
+    return parse_tag(tree, parent)
+
+def parse_tag(tag, parent):
+    fun = globals()["tag_%s" % tag.tag.replace("-", "_")]
+    return join(fun(tag, parent))
+
+def parse_subtags(tag, parent=None):
+    yield tag.text
+
+    for subtag in tag:
+        yield parse_tag(subtag, tag)
+
+    yield tag.tail
+
+def handle_subject(tag, parent):
+    yield '?%s\n' % tag.attrib['id']
+
+    first = True
+    for element in tag:
+        if element.tag in ["para", "variablelist", "simplelist",
+                           "command-list", "ircexample"]:
+            if not first:
+                yield "\n"
+            first = False
+
+            if element.attrib.get('title', ''):
+                yield element.attrib['title']
+                yield "\n"
+            yield join(parse_tag(element, tag)).rstrip("\n")
+            yield "\n"
+
+    yield "%\n"
+
+    for element in tag:
+        if element.tag in ["sect1", "sect2"]:
+            yield join(handle_subject(element, tag))
+
+    for element in tag.findall("bitlbee-command"):
+        yield join(handle_command(element))
+
+    for element in tag.findall("bitlbee-setting"):
+        yield join(handle_setting(element))
+
+def handle_command(tag, prefix=''):
+    this_cmd = prefix + tag.attrib['name']
+
+    yield "?%s\n" % this_cmd
+    for syntax in tag.findall("syntax"):
+        yield '\x02Syntax:\x02 %s\n' % syntax.text
+
+    yield "\n"
+    yield join(parse_subtags(tag.find("description"))).rstrip()
+    yield "\n"
+
+    for example in tag.findall("ircexample"):
+        yield "\n\x02Example:\x02\n"
+        yield join(parse_subtags(example)).rstrip()
+        yield "\n"
+
+    yield "%\n"
+
+    for element in tag.findall("bitlbee-command"):
+        yield join(handle_command(element, this_cmd + " "))
+
+def handle_setting(tag):
+    yield "?set %s\n" % tag.attrib['name']
+    yield "\x02Type:\x02 %s\n" % tag.attrib["type"]
+    yield "\x02Scope:\x02 %s\n" % tag.attrib["scope"]
+
+    if tag.find("default") is not None:
+        yield "\x02Default:\x02 %s\n" % tag.findtext("default")
+
+    if tag.find("possible-values") is not None:
+        yield "\x02Possible Values:\x02 %s\n" % tag.findtext("possible-values")
+
+    yield "\n"
+    yield join(parse_subtags(tag.find("description"))).rstrip()
+    yield "\n%\n"
+
+tag_preface = handle_subject
+tag_chapter = handle_subject
+tag_sect1 = handle_subject
+tag_sect2 = handle_subject
+
+tag_ulink = parse_subtags
+tag_note = parse_subtags
+tag_book = parse_subtags
+tag_ircexample = parse_subtags
+
+def tag_include(tag, parent):
+    return parse_file(tag.attrib['href'], tag)
+
+def tag_para(tag, parent):
+    return join(parse_subtags(tag)) + "\n\n"
+
+def tag_emphasis(tag, parent):
+    return "\x02%s\x02%s" % (tag.text, tag.tail)
+
+def tag_ircline(tag, parent):
+    return "\x02<%s>\x02 %s\n" % (tag.attrib['nick'], join(parse_subtags(tag)))
+
+def tag_ircaction(tag, parent):
+    return "\x02* %s\x02 %s\n" % (tag.attrib['nick'], join(parse_subtags(tag)))
+
+def tag_command_list(tag, parent):
+    yield "These are all root commands. See \x02help <command name>\x02 " \
+          "for more details on each command.\n\n"
+
+    for subtag in parent.findall("bitlbee-command"):
+        yield " * \x02%s\x02 - %s\n" % \
+            (subtag.attrib['name'],
+             subtag.findtext("short-description"))
+
+    yield "\nMost commands can be shortened. For example instead of " \
+          "\x02account list\x02, try \x02ac l\x02.\n\n"
+
+def tag_variablelist(tag, parent):
+    for subtag in tag:
+        yield " \x02%s\x02 - %s\n" % \
+            (subtag.findtext("term"),
+             join(parse_subtags(subtag.find("listitem/para"))))
+    yield '\n'
+
+def tag_simplelist(tag, parent):
+    for subtag in tag:
+        yield " - %s\n" % join(parse_subtags(subtag))
+    yield '\n'
+
+def main():
+    txt = parse_file(IN_FILE)
+    open(OUT_FILE, "w").write(txt)
+
+if __name__ == '__main__':
+    main()

--- a/protocols/skype/Makefile
+++ b/protocols/skype/Makefile
@@ -6,17 +6,8 @@ endif
 DATE := $(shell date +%Y-%m-%d)
 INSTALL = install
 
-
-ifdef ASCIIDOC
-MANPAGES = skyped.1
-else
-MANPAGES =
-endif
-
-all: $(MANPAGES)
-
+all:
 clean:
-	rm -f $(MANPAGES)
 
 # take this from the kernel
 check:
@@ -28,13 +19,11 @@ test: all
 doc: $(MANPAGES)
 
 install-doc: doc
-ifdef ASCIIDOC
 	$(INSTALL) -d $(DESTDIR)$(MANDIR)/man1
 	$(INSTALL) -m644 $(MANPAGES) $(DESTDIR)$(MANDIR)/man1
-endif
 
 uninstall-doc:
 	rm -f $(DESTDIR)$(MANDIR)/man1/skyped.1*
 
 %.1: $(_SRCDIR_)%.txt $(_SRCDIR_)asciidoc.conf
-	a2x --asciidoc-opts="-f $(_SRCDIR_)asciidoc.conf" -a bee_date=$(DATE) -f manpage -D . $<
+	a2x --asciidoc-opts="-f $(_SRCDIR_)asciidoc.conf" -a bee_date=$(DATE) -f manpage $<

--- a/protocols/skype/skyped.1
+++ b/protocols/skype/skyped.1
@@ -1,0 +1,207 @@
+'\" t
+.\"     Title: skyped
+.\"    Author: [see the "AUTHOR" section]
+.\" Generator: DocBook XSL Stylesheets v1.78.1 <http://docbook.sf.net/>
+.\"      Date: 123
+.\"    Manual: BitlBee manual
+.\"    Source: BitlBee
+.\"  Language: English
+.\"
+.TH "SKYPED" "1" "123" "BitlBee" "BitlBee manual"
+.\" -----------------------------------------------------------------
+.\" * Define some portability stuff
+.\" -----------------------------------------------------------------
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.\" http://bugs.debian.org/507673
+.\" http://lists.gnu.org/archive/html/groff/2009-02/msg00013.html
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.ie \n(.g .ds Aq \(aq
+.el       .ds Aq '
+.\" -----------------------------------------------------------------
+.\" * set default formatting
+.\" -----------------------------------------------------------------
+.\" disable hyphenation
+.nh
+.\" disable justification (adjust text to left margin only)
+.ad l
+.\" -----------------------------------------------------------------
+.\" * MAIN CONTENT STARTS HERE *
+.\" -----------------------------------------------------------------
+.SH "NAME"
+skyped \- allows remote control of the Skype GUI client
+.SH "SYNOPSIS"
+.sp
+skyped [<options>]
+.SH "DESCRIPTION"
+.sp
+Skype supports remote control of the GUI client only via X11 or DBus messages\&. This is hard in case you want remote control\&. This daemon listens on a TCP port and runs on the same machine where the GUI client runs\&. It passes all the input it gets to Skype directly, except for a few commands which is related to authentication\&. The whole communication is done via SSL\&.
+.SH "CONFIGURATION"
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+Set up
+~/\&.skyped/skyped\&.conf: Create the
+~/\&.skyped
+directory, copy
+skyped\&.conf
+and
+skyped\&.cnf
+from
+/usr/local/etc/skyped/
+to
+~/\&.skyped, adjust
+username
+and
+password\&. The
+username
+should be your Skype login and the
+password
+can be whatever you want, but you will have to specify that one when adding the Skype account to BitlBee (see later)\&.
+.RE
+.if n \{\
+.sp
+.\}
+.RS 4
+.it 1 an-trap
+.nr an-no-space-flag 1
+.nr an-break-flag 1
+.br
+.ps +1
+\fBNote\fR
+.ps -1
+.br
+.sp
+Here, and later \- /usr/local/etc can be different on your installation if you used the \-\-sysconfdir switch when running the configure of BitlBee\&.
+.sp .5v
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+Generate the SSL pem files:
+.RE
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+$ cd ~/\&.skyped
+$ openssl req \-new \-x509 \-days 365 \-nodes \-config skyped\&.cnf \-out skyped\&.cert\&.pem \e
+        \-keyout skyped\&.key\&.pem
+.fi
+.if n \{\
+.RE
+.\}
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+Start
+skyped
+(the TCP server), initially without detaching and enabling debug messages:
+.RE
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+$ skyped \-d \-n
+.fi
+.if n \{\
+.RE
+.\}
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+Start your
+IRC
+client, connect to BitlBee and add your account:
+.RE
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+account add skype <user> <pass>
+.fi
+.if n \{\
+.RE
+.\}
+.sp
+<user> should be your Skype account name, <pass> should be the one you declared in skyped\&.conf\&.
+.SH "OPTIONS"
+.PP
+\-c, \-\-config
+.RS 4
+Path to configuration file (default: $HOME/\&.skyped/skyped\&.conf)
+.RE
+.PP
+\-d, \-\-debug
+.RS 4
+Enable debug messages
+.RE
+.PP
+\-h, \-\-help
+.RS 4
+Show short summary of options
+.RE
+.PP
+\-H, \-\-host
+.RS 4
+Set the tcp host (default: 0\&.0\&.0\&.0)
+.RE
+.PP
+\-l, \-\-log
+.RS 4
+Set the log file in background mode (default: none)
+.RE
+.PP
+\-m, \-\-mock=<file>
+.RS 4
+Mock mode: replay session from file, instead of connecting to Skype\&.
+.RE
+.PP
+\-n, \-\-nofork
+.RS 4
+Don\(cqt run as daemon in the background
+.RE
+.PP
+\-s, \-\-dont\-start\-skype
+.RS 4
+Assume that skype is running independently, don\(cqt try to start/stop it\&.
+.RE
+.PP
+\-p, \-\-port
+.RS 4
+Set the tcp port (default: 2727)
+.RE
+.PP
+\-v, \-\-version
+.RS 4
+Display version information
+.RE
+.SH "AUTHOR"
+.sp
+Written by Miklos Vajna <vmiklos@vmiklos\&.hu>


### PR DESCRIPTION
This would mean changing one build dependency for another, but one that is way more common at least. (Fun fact: the xslt stuff depends on perl)

It generates *almost* the same thing as the xslt - a bit better if you ask me, since it correctly handles a few <emphasis> tags in the middle of the text, which were previously stripped. One example of that is:

    Favo<emphasis>u</emphasis>rite the given user [...]

Outputs `Favo\x02u\x02rite` with this script, `Favorite` with the xslt. (That's actually an accidental feature)

The script works in python2 and python3 and only uses the stdlib

-----

The full diff between the old generated help.txt and the new help.txt

```diff
--- help.txt	2015-05-16 01:52:21.000000000 -0300
+++ help2.txt	2015-05-16 01:46:06.000000000 -0300
@@ -57,7 +57,7 @@
 Now you might want to add some contacts, to do this we will use the \x02add\x02 command. It needs two arguments: a connection ID (which can be a number (try \x02account list\x02), protocol name or (part of) the screenname) and the user's handle. It is used in the following way: \x02add <connection> <handle>\x02
 
 \x02<you>\x02 add 0 r2d2@example.com
-\x02* r2d2\x02  has joined &bitlbee
+\x02* r2d2\x02  has joined \x02&bitlbee\x02
 
 In this case r2d2 is online, since he/she joins the channel immediately. If the user is not online you will not see them join until they log on.
 
@@ -276,7 +276,7 @@
 
 \x02Example:\x02
 \x02<ctrlsoft>\x02 add 3 gryp@jabber.org grijp
-\x02* grijp\x02 has joined &bitlbee
+\x02* grijp\x02 has joined \x02&bitlbee\x02
 %
 ?info
 \x02Syntax:\x02 info <connection> <handle>
@@ -286,7 +286,7 @@
 
 \x02Example:\x02
 \x02<ctrlsoft>\x02 info 0 72696705
-\x02<root>\x02 User info - UIN: 72696705   Nick: Lintux   First/Last name: Wilmer van der Gaast   E-mail: lintux@lintux.cx
+\x02<root>\x02 User info - UIN: 72696705 Nick: Lintux First/Last name: Wilmer van der Gaast E-mail: lintux@lintux.cx
 %
 ?remove
 \x02Syntax:\x02 remove <nick>
@@ -295,7 +295,7 @@
 
 \x02Example:\x02
 \x02<ctrlsoft>\x02 remove gryp
-\x02* gryp\x02 has quit [Leaving...]
+\x02* gryp\x02 has quit \x02[Leaving...]\x02
 %
 ?block
 \x02Syntax:\x02 block <nick>
@@ -426,7 +426,7 @@
 
 \x02Example:\x02
 \x02<itsme>\x02 rename itsme_ you
-\x02* itsme_\x02 is now known as you
+\x02* itsme_\x02 is now known as \x02you\x02
 %
 ?yes
 \x02Syntax:\x02 yes [<number>]
@@ -661,7 +661,7 @@
  \x02report <screenname|#id>\x02 - Report the given user (or the user who posted the tweet with the given ID) for sending spam. This will also block them.
  \x02follow <screenname>\x02 - Start following a person
  \x02unfollow <screenname>\x02 - Stop following a person
- \x02favourite <screenname|#id>\x02 - Favourite the given user's most recent tweet, or the given tweet ID.
+ \x02favourite <screenname|#id>\x02 - Favo\x02u\x02rite the given user's most recent tweet, or the given tweet ID.
  \x02post <message>\x02 - Post a tweet
  \x02url <screenname|#id>\x02 - Show URL for a tweet to open it in a browser (and see context)
 
```