### PR TITLE
teach nick_lc to handle # and other non-letters correctly

### DIFF
--- a/nick.c
+++ b/nick.c
@@ -367,9 +367,13 @@ int nick_lc(irc_t *irc, char *nick)
 	int i;
 
 	if (tab['A'] == 0) {
+		/* initialize table so nonchars are mapped to themselves */
+		for (i = 0; i < sizeof(tab); i++) {
+			tab[i] = i;
+		}
+		/* replace uppercase chars with lowercase chars */
 		for (i = 0; nick_lc_chars[i]; i++) {
 			tab[(int) nick_uc_chars[i]] = nick_lc_chars[i];
-			tab[(int) nick_lc_chars[i]] = nick_lc_chars[i];
 		}
 	}
 


### PR DESCRIPTION
So I've been running the `feat/hip-cat` branch and ran into a problem with channels that have a # in the name.

Let's say there are hipchat channels named `#foo` and `#bar`. Currently what will happen is when bitlbee starts up, it gets the channel list, and as it's adding the channels it tries to create IRC names for these channels. What will happen is currently in `nick_lc()`, the `tab` table is initialized to zeroes for things that aren't defined in `nick_uc_chars` or `nick_lc_chars`. So `nick_lc` will map `"#foo"` to `""`, because the # character gets replaced with `\0`. So ultimately, what happens is bitlbee will create IRC channels for `#foo` and `#bar` as `#_` and `#__`, which isn't very useful.

With this change, `nick_lc` will map `"#foo"` to `"#foo"`, and consequently the hipchat channels will be mapped to `##foo` and `##bar`. I can join the channels and whatnot, and everything seems to work OK with this change.

The original impetus for this change is for the `feat/hip-cat` branch, but I think that this is generally a bug in bitlbee and isn't really hipchat specific.

cc @dequis who seems to be driving the hipchat stuff