### PR TITLE
Revert "Provides" "fix" in debian control file.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -21,7 +21,6 @@ Description: An IRC to other chat networks gateway (default version)
 Package: bitlbee-libpurple
 Architecture: any
 Depends: ${misc:Depends}, ${shlibs:Depends}, debianutils (>= 1.16), bitlbee-common (= ${source:Version})
-Provides: bitlbee (= ${source:Version})
 Conflicts: bitlbee
 Replaces: bitlbee
 Description: An IRC to other chat networks gateway (using libpurple)


### PR DESCRIPTION
As "Provides" doesn't seem to work as expected, if plugin makers are sure their code works with -libpurple, they have to explicitly set an alternate dependency.