### PR TITLE
twitter: show full url in the url command, with username

### DIFF
--- a/protocols/twitter/twitter.c
+++ b/protocols/twitter/twitter.c
@@ -1011,11 +1011,7 @@ static void twitter_handle_command(struct im_connection *ic, char *message)
 		if (!id) {
 			twitter_log(ic, "Tweet `%s' does not exist", cmd[1]);
 		} else {
-			/* More common link is twitter.com/$UID/status/$ID (and that's
-			 * what this will 302 to) but can't generate that since for RTs,
-			 * bu here points at the retweeter while id contains the id of
-			 * the original message. */
-			twitter_log(ic, "https://twitter.com/statuses/%lld", id);
+			twitter_status_show_url(ic, id);
 		}
 		goto eof;
 

--- a/protocols/twitter/twitter_lib.h
+++ b/protocols/twitter/twitter_lib.h
@@ -95,6 +95,7 @@ void twitter_status_destroy(struct im_connection *ic, guint64 id);
 void twitter_status_retweet(struct im_connection *ic, guint64 id);
 void twitter_report_spam(struct im_connection *ic, char *screen_name);
 void twitter_favourite_tweet(struct im_connection *ic, guint64 id);
+void twitter_status_show_url(struct im_connection *ic, guint64 id);
 
 #endif //_TWITTER_LIB_H
 


### PR DESCRIPTION
By asking the server for the username.

Storing the username somewhere would have made sense, but this command
isn't going to be used very often, so, whatever.

------

```
00:12 < justinbieber> [10] RT @SaturdayOnline: NOW PLAYING @justinbieber @Skrillex & @diplo 'Where Are U Now' on #SaturdayNightOnline with @OnAirRomeo THANKS FOR THE REQUESTS!
00:12 < justinbieber> [11] Watch me and my bro on snapchat
00:12 < justinbieber> [12] rickthesizzler

00:12 <@dx|ebooks> url 12
00:12 <@root> https://twitter.com/justinbieber/status/607736317363945472
00:13 <@dx|ebooks> url 11
00:13 <@root> https://twitter.com/justinbieber/status/607735726646509568
00:13 <@dx|ebooks> url 10
00:13 <@root> https://twitter.com/SaturdayOnline/status/607386147396943872

00:13 <@dx|ebooks> post lol https://twitter.com/SaturdayOnline/status/607386147396943872
00:13 <@root> You: [14] lol <https://t.co/ascLN5XYQh> [@SaturdayOnline: NOW PLAYING @justinbieber @Skrillex & @diplo 'Where Are U Now' on #SaturdayNightOnline with @OnAirRomeo THANKS FOR THE REQUESTS!]
```

Also skrillex and justin bieber seem to be friends or something, since I keep seeing them mentioned together in this test account. Weird stuff. I guess that says a lot about those who still listen skrillex in 2015, since dubstep died like two years ago.