### PR TITLE
Allow setting the plugin dir at runtime

### DIFF
--- a/conf.c
+++ b/conf.c
@@ -247,6 +247,9 @@ static int conf_loadini(conf_t *conf, char *file)
 			} else if (g_strcasecmp(ini->key, "configdir") == 0) {
 				g_free(conf->configdir);
 				conf->configdir = g_strdup(ini->value);
+			} else if (g_strcasecmp(ini->key, "plugindir") == 0) {
+				g_free(conf->plugindir);
+				conf->plugindir = g_strdup(ini->value);
 			} else if (g_strcasecmp(ini->key, "motdfile") == 0) {
 				g_free(conf->motdfile);
 				conf->motdfile = g_strdup(ini->value);


### PR DESCRIPTION
This enables the use of bitlbee plugins in scenarios where there is no write access to the bitlbee lib/ directory.

One example is the NixOS linux distribution (which I'm currently packaging a bitlbee plugin for), where post-installation modification of a package (e.g. bitlbee) by another package (e.g. bitlbee-facebook) is not possible.

Another example would be a user without root access building and using a plugin with a system-provided (i.e. installed by root) bitlbee.