### PR TITLE
IRCv3 multi-prefix... but mostly just adding prefixes to WHO

### DIFF
--- a/irc.h
+++ b/irc.h
@@ -68,6 +68,7 @@ typedef enum {
 
 typedef enum {
 	CAP_SASL = (1 << 0),
+	CAP_MULTI_PREFIX = (1 << 1),
 } irc_cap_flag_t;
 
 struct irc_user;
@@ -308,6 +309,7 @@ int irc_channel_name_cmp(const char *a_, const char *b_);
 char *irc_channel_name_gen(irc_t *irc, const char *name);
 gboolean irc_channel_name_hint(irc_channel_t *ic, const char *name);
 void irc_channel_update_ops(irc_channel_t *ic, char *value);
+char irc_channel_user_get_prefix(irc_channel_user_t *icu);
 char *set_eval_irc_channel_ops(struct set *set, char *value);
 gboolean irc_channel_wants_user(irc_channel_t *ic, irc_user_t *iu);
 

--- a/irc_cap.c
+++ b/irc_cap.c
@@ -38,6 +38,7 @@ typedef struct {
 
 static const cap_info_t supported_caps[] = {
 	{"sasl", CAP_SASL},
+	{"multi-prefix", CAP_MULTI_PREFIX},
 	{NULL},
 };
 

--- a/irc_channel.c
+++ b/irc_channel.c
@@ -428,6 +428,18 @@ void irc_channel_set_mode(irc_channel_t *ic, const char *s)
 	}
 }
 
+char irc_channel_user_get_prefix(irc_channel_user_t *icu)
+{
+	if (icu->flags & IRC_CHANNEL_USER_OP) {
+		return '@';
+	} else if (icu->flags & IRC_CHANNEL_USER_HALFOP) {
+		return '%';
+	} else if (icu->flags & IRC_CHANNEL_USER_VOICE) {
+		return '+';
+	}
+	return 0;
+}
+
 void irc_channel_auto_joins(irc_t *irc, account_t *acc)
 {
 	GSList *l;


### PR DESCRIPTION
We can't actually have multiple prefixes internally, so the only thing
missing for multi-prefix compliance is actually having the prefix in the
WHO reply, which is a rfc1459 thing.

Note to future self: check irc logs for the implementation I threw away.
The one that actually handled multiple prefixes. I hope that's useful.

------

Building a house of cards of pull requests.

This one (`wip/ircv3+sasl+multi-prefix`) applies against `wip/irc3+sasl`.

I suspect branches aren't meant to be used like this.

----

This one would normally not require any review, but it's 5am and the `char status_prefix[3]` thing is probably a bit too clever. It works, and I believe it's sane, but valgrind isn't going to tell me if i'm doing dumb stuff because it's in the stack.