### PR TITLE
IRC self-message support (messages sent by yourself from other clients)

### DIFF
--- a/doc/user-guide/commands.xml
+++ b/doc/user-guide/commands.xml
@@ -1403,6 +1403,33 @@
 		</description>
 	</bitlbee-setting>
 
+	<bitlbee-setting name="self_messages" type="string" scope="global">
+		<default>true</default>
+		<possible-values>true, false, prefix, prefix_notice</possible-values>
+
+		<description>
+			<para>
+				Change this setting to customize how (or whether) to show self-messages, which are messages sent by yourself from other locations (for example, mobile clients), for IM protocols that support it.
+			</para>
+
+			<para>
+				When this is set to "true", it will send those messages in the "standard" way, which is a PRIVMSG with source and target fields swapped.
+			</para>
+			
+			<para>
+				Since this isn't very well supported by some clients (the messages might appear in the wrong window), you can set it to "prefix" to show them as a normal message prefixed with "-> ", or use "prefix_notice" which is the same thing but with a NOTICE instead.
+			</para>
+
+			<para>
+				You can also set it to "false" to disable these messages completely.
+			</para>
+
+			<para>
+				This setting only applies to private messages. Self messages in groupchats are always shown, since they haven't caused issues in any clients so far.
+			</para>
+		</description>
+	</bitlbee-setting>
+
 	<bitlbee-setting name="server" type="string" scope="account">
 		<description>
 			<para>

--- a/irc.c
+++ b/irc.c
@@ -128,6 +128,7 @@ irc_t *irc_new(int fd)
 	s->flags |= SET_HIDDEN;
 	s = set_add(&b->set, "show_offline", "false", set_eval_bw_compat, irc);
 	s->flags |= SET_HIDDEN;
+	s = set_add(&b->set, "self_messages", "true", set_eval_self_messages, irc);
 	s = set_add(&b->set, "simulate_netsplit", "true", set_eval_bool, irc);
 	s = set_add(&b->set, "timezone", "local", set_eval_timezone, irc);
 	s = set_add(&b->set, "to_char", ": ", set_eval_to_char, irc);

--- a/irc.h
+++ b/irc.h
@@ -353,6 +353,7 @@ void irc_user_quit(irc_user_t *iu, const char *msg);
 /* irc_util.c */
 char *set_eval_timezone(struct set *set, char *value);
 char *irc_format_timestamp(irc_t *irc, time_t msg_ts);
+char *set_eval_self_messages(struct set *set, char *value);
 
 /* irc_im.c */
 void bee_irc_channel_update(irc_t *irc, irc_channel_t *ic, irc_user_t *iu);

--- a/irc_util.c
+++ b/irc_util.c
@@ -118,3 +118,15 @@ char *irc_format_timestamp(irc_t *irc, time_t msg_ts)
 		                       msg.tm_hour, msg.tm_min, msg.tm_sec);
 	}
 }
+
+
+char *set_eval_self_messages(set_t *set, char *value)
+{
+	if (is_bool(value) ||
+	    g_strcasecmp(value, "prefix") == 0 ||
+	    g_strcasecmp(value, "prefix_notice") == 0) {
+		return value;
+	} else {
+		return SET_INVALID;
+	}
+}

--- a/protocols/bee.h
+++ b/protocols/bee.h
@@ -104,7 +104,7 @@ typedef struct bee_ui_funcs {
 	/* State info is already updated, old is provided in case the UI needs a diff. */
 	gboolean (*user_status)(bee_t *bee, struct bee_user *bu, struct bee_user *old);
 	/* On every incoming message. sent_at = 0 means unknown. */
-	gboolean (*user_msg)(bee_t *bee, bee_user_t *bu, const char *msg, time_t sent_at);
+	gboolean (*user_msg)(bee_t *bee, bee_user_t *bu, const char *msg, guint32 flags, time_t sent_at);
 	/* Flags currently defined (OPT_TYPING/THINKING) in nogaim.h. */
 	gboolean (*user_typing)(bee_t *bee, bee_user_t *bu, guint32 flags);
 	/* CTCP-like stuff (buddy action) response */
@@ -117,7 +117,7 @@ typedef struct bee_ui_funcs {
 	gboolean (*chat_free)(bee_t *bee, struct groupchat *c);
 	/* System messages of any kind. */
 	gboolean (*chat_log)(bee_t *bee, struct groupchat *c, const char *text);
-	gboolean (*chat_msg)(bee_t *bee, struct groupchat *c, bee_user_t *bu, const char *msg, time_t sent_at);
+	gboolean (*chat_msg)(bee_t *bee, struct groupchat *c, bee_user_t *bu, const char *msg, guint32 flags, time_t sent_at);
 	gboolean (*chat_add_user)(bee_t *bee, struct groupchat *c, bee_user_t *bu);
 	gboolean (*chat_remove_user)(bee_t *bee, struct groupchat *c, bee_user_t *bu, const char *reason);
 	gboolean (*chat_topic)(bee_t *bee, struct groupchat *c, const char *new_topic, bee_user_t *bu);

--- a/protocols/bee_chat.c
+++ b/protocols/bee_chat.c
@@ -94,16 +94,15 @@ static gboolean handle_is_self(struct im_connection *ic, const char *handle)
 	       (ic->acc->prpl->handle_cmp(ic->acc->user, handle) == 0);
 }
 
-void imcb_chat_msg(struct groupchat *c, const char *who, char *msg, uint32_t flags, time_t sent_at)
+void imcb_chat_msg(struct groupchat *c, const char *who, char *msg, guint32 flags, time_t sent_at)
 {
 	struct im_connection *ic = c->ic;
 	bee_t *bee = ic->bee;
 	bee_user_t *bu;
-	gboolean temp;
+	gboolean temp = FALSE;
 	char *s;
 
-	/* Gaim sends own messages through this too. IRC doesn't want this, so kill them */
-	if (handle_is_self(ic, who)) {
+	if (handle_is_self(ic, who) && !(flags & OPT_SELFMESSAGE)) {
 		return;
 	}
 
@@ -121,7 +120,7 @@ void imcb_chat_msg(struct groupchat *c, const char *who, char *msg, uint32_t fla
 	}
 
 	if (bee->ui->chat_msg) {
-		bee->ui->chat_msg(bee, c, bu, msg, sent_at);
+		bee->ui->chat_msg(bee, c, bu, msg, flags, sent_at);
 	}
 
 	if (temp) {

--- a/protocols/bee_user.c
+++ b/protocols/bee_user.c
@@ -246,7 +246,7 @@ void imcb_buddy_times(struct im_connection *ic, const char *handle, time_t login
 	bu->idle_time = idle;
 }
 
-void imcb_buddy_msg(struct im_connection *ic, const char *handle, const char *msg, uint32_t flags, time_t sent_at)
+void imcb_buddy_msg(struct im_connection *ic, const char *handle, const char *msg, guint32 flags, time_t sent_at)
 {
 	bee_t *bee = ic->bee;
 	bee_user_t *bu;
@@ -264,7 +264,7 @@ void imcb_buddy_msg(struct im_connection *ic, const char *handle, const char *ms
 	}
 
 	if (bee->ui->user_msg && bu) {
-		bee->ui->user_msg(bee, bu, msg, sent_at);
+		bee->ui->user_msg(bee, bu, msg, flags, sent_at);
 	} else {
 		imcb_log(ic, "Message from unknown handle %s:\n%s", handle, msg);
 	}
@@ -296,7 +296,7 @@ void imcb_notify_email(struct im_connection *ic, char *format, ...)
 	g_free(msg);
 }
 
-void imcb_buddy_typing(struct im_connection *ic, const char *handle, uint32_t flags)
+void imcb_buddy_typing(struct im_connection *ic, const char *handle, guint32 flags)
 {
 	bee_user_t *bu;
 

--- a/protocols/nogaim.h
+++ b/protocols/nogaim.h
@@ -69,6 +69,7 @@
 #define OPT_NOOTR       0x00001000 /* protocol not suitable for OTR */
 #define OPT_PONGS       0x00010000 /* Service sends us keep-alives */
 #define OPT_PONGED      0x00020000 /* Received a keep-alive during last interval */
+#define OPT_SELFMESSAGE 0x00080000 /* A message sent by self from another location */
 
 /* ok. now the fun begins. first we create a connection structure */
 struct im_connection {
@@ -324,7 +325,7 @@ G_MODULE_EXPORT void imcb_rename_buddy(struct im_connection *ic, const char *han
 G_MODULE_EXPORT void imcb_buddy_nick_hint(struct im_connection *ic, const char *handle, const char *nick);
 G_MODULE_EXPORT void imcb_buddy_action_response(bee_user_t *bu, const char *action, char * const args[], void *data);
 
-G_MODULE_EXPORT void imcb_buddy_typing(struct im_connection *ic, const char *handle, uint32_t flags);
+G_MODULE_EXPORT void imcb_buddy_typing(struct im_connection *ic, const char *handle, guint32 flags);
 G_MODULE_EXPORT struct bee_user *imcb_buddy_by_handle(struct im_connection *ic, const char *handle);
 G_MODULE_EXPORT void imcb_clean_handle(struct im_connection *ic, char *handle);
 


### PR DESCRIPTION
This adds an OPT_SELFMESSAGE flag that can be passed to imcb_buddy_msg()
or imcb_chat_msg() to indicate that the protocol knows that the message
being sent is a self message.

This needs to be explicit since the old behavior is to silently drop
these messages, which also removed server echoes.

This commit doesn't break API/ABI, the flags parameters that were added
are all internal (between protocols and UI code)

On the irc protocol side, the situation isn't very nice, since some
clients put these messages in the wrong window. Irssi, hexchat and mirc
get this wrong. Irssi 0.8.18 has a fix for it, and the others have
scripts to patch it.

But meanwhile, there's a "self_messages" global setting that lets users
disable this, or get them as normal messages / notices with a "->"
prefix, which loosely imitates the workaround used by the ZNC
"privmsg_prefix" module.