### PR TITLE
Replace <br/> and <br /> with \n in strip_html

### DIFF
--- a/lib/misc.c
+++ b/lib/misc.c
@@ -186,6 +186,10 @@ void strip_html(char *in)
 					*(s++) = '\x1f';
 				} else if (g_strncasecmp(cs + 1, "br", taglen) == 0) {
 					*(s++) = '\n';
+				} else if (g_strncasecmp(cs + 1, "br/", taglen) == 0) {
+					*(s++) = '\n';
+				} else if (g_strncasecmp(cs + 1, "br /", taglen) == 0) {
+					*(s++) = '\n';
 				}
 				in++;
 			} else {


### PR DESCRIPTION
This pull request patches strip_html to insert a line break in case of `<br/>` and `<br />`.

Reason: The OTR-Plugin in gajim sends `<br/>`, which results in missing linebreaks in bitlbee.
https://github.com/python-otr/gajim-otr/blob/0613803545b7972ab57059cfb312d62a5a9dbbf1/src/gotr/otrmodule.py#L695