### PR TITLE
Allow NULL callback functions in http_dorequest

### DIFF
--- a/lib/http_client.c
+++ b/lib/http_client.c
@@ -161,7 +161,9 @@ error:
 		req->status_string = g_strdup("Error while writing HTTP request");
 	}
 
-	req->func(req);
+	if (req->func != NULL) {
+		req->func(req);
+	}
 	http_free(req);
 	return FALSE;
 }
@@ -298,7 +300,9 @@ cleanup:
 		       req->status_string ? req->status_string : "NULL");
 	}
 
-	req->func(req);
+	if (req->func != NULL) {
+		req->func(req);
+	}
 	http_free(req);
 	return FALSE;
 }
@@ -411,7 +415,7 @@ static http_ret_t http_process_data(struct http_request *req, const char *buffer
 		req->body_size = req->sblen - pos;
 	}
 
-	if ((req->flags & HTTPC_STREAMING) && req->reply_body) {
+	if ((req->flags & HTTPC_STREAMING) && req->reply_body && req->func != NULL) {
 		req->func(req);
 	}
 


### PR DESCRIPTION
Check callback function supplied to http_dorequest and only run it if it is
not NULL.

While it is not the usual case there are some times when there is no need to
check the results of a http request. Using a NULL pointer is much more
convenient than creating noop functions.