### PR TITLE
proxy_disconnect()

### DIFF
--- a/lib/http_client.c
+++ b/lib/http_client.c
@@ -699,7 +699,7 @@ void http_close(struct http_request *req)
 	if (req->ssl) {
 		ssl_disconnect(req->ssl);
 	} else {
-		closesocket(req->fd);
+		proxy_disconnect(req->fd);
 	}
 
 	http_free(req);

--- a/lib/proxy.h
+++ b/lib/proxy.h
@@ -48,5 +48,6 @@ extern char proxyuser[128];
 extern char proxypass[128];
 
 G_MODULE_EXPORT int proxy_connect(const char *host, int port, b_event_handler func, gpointer data);
+G_MODULE_EXPORT void proxy_disconnect(int fd);
 
 #endif /* _PROXY_H_ */

--- a/lib/ssl_gnutls.c
+++ b/lib/ssl_gnutls.c
@@ -454,7 +454,7 @@ void ssl_disconnect(void *conn_)
 		gnutls_bye(conn->session, GNUTLS_SHUT_WR);
 	}
 
-	closesocket(conn->fd);
+	proxy_disconnect(conn->fd);
 
 	if (conn->session) {
 		gnutls_deinit(conn->session);

--- a/lib/ssl_nss.c
+++ b/lib/ssl_nss.c
@@ -225,8 +225,8 @@ ssl_connected_failure:
 
 	if (conn->prfd) {
 		PR_Close(conn->prfd);
-	}
-	if (source >= 0) {
+	} else if (source >= 0) {
+		/* proxy_disconnect() would be redundant here */
 		closesocket(source);
 	}
 	g_free(conn->hostname);
@@ -304,6 +304,8 @@ void ssl_disconnect(void *conn_)
 
 	if (conn->prfd) {
 		PR_Close(conn->prfd);
+	} else if (conn->fd) {
+		proxy_disconnect(conn->fd);
 	}
 
 	g_free(conn->hostname);

--- a/lib/ssl_openssl.c
+++ b/lib/ssl_openssl.c
@@ -130,7 +130,7 @@ static gboolean ssl_connected(gpointer data, gint source, b_input_condition cond
 		/* Right now we don't have any verification functionality for OpenSSL. */
 		conn->func(conn->data, 1, NULL, cond);
 		if (source >= 0) {
-			closesocket(source);
+			proxy_disconnect(source);
 		}
 		ssl_conn_free(conn);
 
@@ -275,7 +275,7 @@ void ssl_disconnect(void *conn_)
 		SSL_shutdown(conn->ssl);
 	}
 
-	closesocket(conn->fd);
+	proxy_disconnect(conn->fd);
 
 	ssl_conn_free(conn);
 }

--- a/protocols/jabber/jabber.c
+++ b/protocols/jabber/jabber.c
@@ -344,7 +344,7 @@ static void jabber_logout(struct im_connection *ic)
 		ssl_disconnect(jd->ssl);
 	}
 	if (jd->fd >= 0) {
-		closesocket(jd->fd);
+		proxy_disconnect(jd->fd);
 	}
 
 	if (jd->tx_len) {

--- a/protocols/oscar/conn.c
+++ b/protocols/oscar/conn.c
@@ -316,7 +316,7 @@ void aim_conn_close(aim_conn_t *deadconn)
 {
 
 	if (deadconn->fd >= 3) {
-		closesocket(deadconn->fd);
+		proxy_disconnect(deadconn->fd);
 	}
 	deadconn->fd = -1;
 	if (deadconn->handlerlist) {


### PR DESCRIPTION
Four commits here, first two are preparation for the third which is the main implementation, and the fourth uses that function in a bunch of places.

The whole diff isn't very interesting, so maybe just look into the third one, 4e365cec5275e3dec782af3ec0bc9a651cc2b831. The implementation is straightforward, but still would like a lgtm before merging. Or maybe not, and maybe i'll merge it anyway.

This addresses the issue described at length in https://bugs.bitlbee.org/bitlbee/ticket/1198

----
* **proxy: Use an array of function pointers for `proxy_connect_*`**

    Just cleanup.

* **proxy: Turn `phb_close()` into `phb_free()`, use it for all `g_free(phb)`**

    More cleanup.

* **Add `proxy_disconnect()` to interrupt possibly pending connections**

    Fixes trac ticket 1198, https://bugs.bitlbee.org/bitlbee/ticket/1198

    This function can be used as a safe drop-in replacement to `closesocket()`

    If a proxy connection is pending (connected callback still not called),
    it looks up the PHB in a hash table indexed by fd. If it is there, it
    closes, frees the phb and avoids further calls to the callback.
    If it is not in there, it just does `closesocket()`

* **Use proxy_disconnect() in http, ssl, jabber, oscar**

    Twitter and MSN are all HTTP/SSL, so they don't need it either.

    The out of tree facebook and steam plugins are also covered by the
    HTTP/SSL changes.

    Yahoo is written in a weird way and doesn't seem to need it (it seems it
    doesn't immediately stop connections when you tell it to logout)