### PR TITLE
Fix https://bugs.bitlbee.org/bitlbee/ticket/415

### DIFF
--- a/irc_im.c
+++ b/irc_im.c
@@ -402,11 +402,6 @@ static gboolean bee_irc_user_nick_update(irc_user_t *iu)
 	bee_user_t *bu = iu->bu;
 	char *newnick;
 
-	if (bu->flags & BEE_USER_ONLINE) {
-		/* Ignore if the user is visible already. */
-		return TRUE;
-	}
-
 	if (nick_saved(bu)) {
 		/* The user already assigned a nickname to this person. */
 		return TRUE;

--- a/protocols/jabber/conference.c
+++ b/protocols/jabber/conference.c
@@ -312,7 +312,6 @@ void jabber_chat_pkt_presence(struct im_connection *ic, struct jabber_buddy *bud
 			/* If JIDs are anonymized, add them to the local
 			   list for the duration of this chat. */
 			imcb_add_buddy(ic, bud->ext_jid, NULL);
-			imcb_buddy_nick_hint(ic, bud->ext_jid, bud->resource);
 		}
 
 		if (bud == jc->me && jc->invite != NULL) {
@@ -327,6 +326,7 @@ void jabber_chat_pkt_presence(struct im_connection *ic, struct jabber_buddy *bud
 		if (s) {
 			*s = 0; /* Should NEVER be NULL, but who knows... */
 		}
+		imcb_buddy_nick_hint(ic, bud->ext_jid, bud->resource);
 		imcb_chat_add_buddy(chat, bud->ext_jid);
 		if (s) {
 			*s = '/';


### PR DESCRIPTION
When I would join a non-anonymous conference room cafe@foo.comm the IRC
nicks were being derived from the participants' jabber ID, and not the
handle with which they joined the room. For example one user in the
roster would be "agarcia" and not "berto". The "berto" name came in the
roster for the room, i.e. a jabber ID of cafe@foo.com/berto.  The name
"berto" doesn't appear anywhere else.  The jabber server is Openfire
3.6.4.

The reason this information wasn't getting propagated correctly appears
to be twofold.  One, the nick_hint wasn't getting set on the buddies for
non-anonymous chats.  Two, setting the nick hint would bail out if the
user was already logged in -- but of course the user is logged in,
that's why I can see them.

This patch fixes both issues.