### PR TITLE
Do not use NOTICE for OTR messages for a given user

### DIFF
--- a/otr.c
+++ b/otr.c
@@ -1399,8 +1399,8 @@ void display_otr_message(void *opdata, ConnContext *ctx, const char *fmt, ...)
 	va_end(va);
 
 	if (u) {
-		/* display as a notice from this particular user */
-		irc_usernotice(u, "%s", msg);
+		/* just show this as a regular message */
+		irc_usermsg(u, "<<\002OTR\002>> %s", msg);
 	} else {
 		irc_rootmsg(irc, "[otr] %s", msg);
 	}


### PR DESCRIPTION
I cannot count how many times I've lost messages from someone because they ended their OTR session and the information was sent in a NOTICE in a user window. I literally cannot count, because I don't know how often it happens. This is really broken behavior and after years of it driving me mad I fixed it myself.

