### PR TITLE
Check global account away setting in WHO replies

### DIFF
--- a/irc_send.c
+++ b/irc_send.c
@@ -347,8 +347,13 @@ void irc_send_who(irc_t *irc, GSList *l, const char *channel)
 			iu = l->data;
 		}
 
-		/* rfc1459 doesn't mention this: G means gone, H means here */
-		status_prefix[0] = iu->flags & IRC_USER_AWAY ? 'G' : 'H';
+		/* If this is the account nick, check configuration to see if away */
+		if (iu == irc->user) {
+			/* rfc1459 doesn't mention this: G means gone, H means here */
+			status_prefix[0] = set_getstr(&irc->b->set, "away") ? 'G' : 'H';
+		} else {
+			status_prefix[0] = iu->flags & IRC_USER_AWAY ? 'G' : 'H';
+		}
 
 		irc_send_num(irc, 352, "%s %s %s %s %s %s :0 %s",
 		             is_channel ? channel : "*", iu->user, iu->host, irc->root->host,


### PR DESCRIPTION
When sending a WHO reply, check if irc_user is the account user.  If so, set away status according to global account away configuration.  Otherwise, reply according to irc_user flags.  This fixes global away status not being shown in IRC clients when WHO polling is enabled, e.g. Quassel IRC.

Fixes:  https://bugs.bitlbee.org/ticket/1247