### PR TITLE
Support for locked-down configurations

### DIFF
--- a/bitlbee.conf
+++ b/bitlbee.conf
@@ -69,6 +69,13 @@
 ## or
 # OperPassword = md5:I0mnZbn1t4R731zzRdDN2/pK7lRX
 
+## AllowAccountAdd
+##
+## Whether to allow registered and identified users to add new accounts using
+## 'account add'
+##
+# AllowAccountAdd 1
+
 ## HostName
 ##
 ## Normally, BitlBee gets a hostname using getsockname(). If you have a nicer

--- a/conf.c
+++ b/conf.c
@@ -56,6 +56,7 @@ conf_t *conf_load(int argc, char *argv[])
 	conf->authmode = AUTHMODE_OPEN;
 	conf->auth_pass = NULL;
 	conf->oper_pass = NULL;
+	conf->allow_account_add = 1;
 	conf->configdir = g_strdup(CONFIG);
 	conf->plugindir = g_strdup(PLUGINDIR);
 	conf->pidfile = g_strdup(PIDFILE);
@@ -245,6 +246,12 @@ static int conf_loadini(conf_t *conf, char *file)
 			} else if (g_strcasecmp(ini->key, "operpassword") == 0) {
 				g_free(conf->oper_pass);
 				conf->oper_pass = g_strdup(ini->value);
+			} else if (g_strcasecmp(ini->key, "allowaccountadd") == 0) {
+				if (!is_bool(ini->value)) {
+					fprintf(stderr, "Invalid %s value: %s\n", ini->key, ini->value);
+					return 0;
+				}
+				conf->allow_account_add = bool2int(ini->value);
 			} else if (g_strcasecmp(ini->key, "hostname") == 0) {
 				g_free(conf->hostname);
 				conf->hostname = g_strdup(ini->value);

--- a/conf.h
+++ b/conf.h
@@ -38,6 +38,7 @@ typedef struct conf {
 	authmode_t authmode;
 	char *auth_pass;
 	char *oper_pass;
+	int allow_account_add;
 	char *hostname;
 	char *configdir;
 	char *plugindir;

--- a/protocols/account.c
+++ b/protocols/account.c
@@ -66,13 +66,13 @@ account_t *account_add(bee_t *bee, struct prpl *prpl, char *user, char *pass)
 	s->flags |= SET_NOSAVE; /* Just for bw compatibility! */
 
 	s = set_add(&a->set, "password", NULL, set_eval_account, a);
-	s->flags |= SET_NOSAVE | SET_NULL_OK | SET_PASSWORD;
+	s->flags |= SET_NOSAVE | SET_NULL_OK | SET_PASSWORD | ACC_SET_LOCKABLE;
 
 	s = set_add(&a->set, "tag", NULL, set_eval_account, a);
 	s->flags |= SET_NOSAVE;
 
 	s = set_add(&a->set, "username", NULL, set_eval_account, a);
-	s->flags |= SET_NOSAVE | ACC_SET_OFFLINE_ONLY;
+	s->flags |= SET_NOSAVE | ACC_SET_OFFLINE_ONLY | ACC_SET_LOCKABLE;
 	set_setstr(&a->set, "username", user);
 
 	/* Hardcode some more clever tag guesses. */

--- a/protocols/account.h
+++ b/protocols/account.h
@@ -62,6 +62,7 @@ int protocol_account_islocal(const char* protocol);
 typedef enum {
 	ACC_SET_OFFLINE_ONLY = 0x02,    /* Allow changes only if the acct is offline. */
 	ACC_SET_ONLINE_ONLY = 0x04,     /* Allow changes only if the acct is online. */
+	ACC_SET_LOCKABLE = 0x08         /* Setting cannot be changed if the account is locked down */
 } account_set_flag_t;
 
 typedef enum {
@@ -69,6 +70,7 @@ typedef enum {
 	ACC_FLAG_STATUS_MESSAGE = 0x02, /* Supports status messages (without being away). */
 	ACC_FLAG_HANDLE_DOMAINS = 0x04, /* Contact handles need a domain portion. */
 	ACC_FLAG_LOCAL = 0x08,          /* Contact list is local. */
+	ACC_FLAG_LOCKED = 0x10,         /* Account is locked (cannot be deleted, certain settings can't changed) */
 } account_flag_t;
 
 #endif

--- a/root_commands.c
+++ b/root_commands.c
@@ -387,6 +387,9 @@ static int cmd_account_set_checkflags(irc_t *irc, set_t *s)
 	} else if (!a->ic && s && s->flags & ACC_SET_ONLINE_ONLY) {
 		irc_rootmsg(irc, "This setting can only be changed when the account is %s-line", "on");
 		return 0;
+	} else if (a->flags & ACC_FLAG_LOCKED && s && s->flags & ACC_SET_LOCKABLE) {
+		irc_rootmsg(irc, "This setting can not be changed for locked accounts");
+		return 0;
 	}
 
 	return 1;
@@ -546,7 +549,10 @@ static void cmd_account(irc_t *irc, char **cmd)
 	}
 
 	if (len >= 1 && g_strncasecmp(cmd[2], "del", len) == 0) {
-		if (a->ic) {
+		if (a->flags & ACC_FLAG_LOCKED) {
+			irc_rootmsg(irc, "Account is locked, can't delete");
+		}
+		else if (a->ic) {
 			irc_rootmsg(irc, "Account is still logged in, can't delete");
 		} else {
 			account_del(irc->b, a);

--- a/root_commands.c
+++ b/root_commands.c
@@ -416,6 +416,11 @@ static void cmd_account(irc_t *irc, char **cmd)
 
 		MIN_ARGS(3);
 
+		if (!global.conf->allow_account_add) {
+			irc_rootmsg(irc, "This server does not allow adding new accounts");
+			return;
+		}
+
 		if (cmd[4] == NULL) {
 			for (a = irc->b->accounts; a; a = a->next) {
 				if (strcmp(a->pass, PASSWORD_PENDING) == 0) {

--- a/root_commands.c
+++ b/root_commands.c
@@ -339,6 +339,10 @@ static int cmd_set_real(irc_t *irc, char **cmd, set_t **head, cmd_set_checkflags
 		set_t *s = set_find(head, set_name);
 		int st;
 
+		if (s && s->flags & SET_LOCKED) {
+			irc_rootmsg(irc, "This setting can not be changed");
+			return 0;
+		}
 		if (s && checkflags && checkflags(irc, s) == 0) {
 			return 0;
 		}

--- a/set.h
+++ b/set.h
@@ -48,6 +48,7 @@ typedef enum {
 	SET_HIDDEN = 0x0200,   /* Don't show up in setting lists. Mostly for internal storage. */
 	SET_PASSWORD = 0x0400, /* Value shows up in settings list as "********". */
 	SET_HIDDEN_DEFAULT = 0x0800, /* Hide unless changed from default. */
+	SET_LOCKED = 0x1000    /* Setting is locked, don't allow changing it */
 } set_flags_t;
 
 typedef struct set {

--- a/storage_xml.c
+++ b/storage_xml.c
@@ -85,7 +85,7 @@ static void handle_settings(struct xt_node *node, set_t **head)
 static xt_status handle_account(struct xt_node *node, gpointer data)
 {
 	struct xml_parsedata *xd = data;
-	char *protocol, *handle, *server, *password = NULL, *autoconnect, *tag;
+	char *protocol, *handle, *server, *password = NULL, *autoconnect, *tag, *locked;
 	char *pass_b64 = NULL;
 	unsigned char *pass_cr = NULL;
 	int pass_len, local = 0;
@@ -98,6 +98,7 @@ static xt_status handle_account(struct xt_node *node, gpointer data)
 	server = xt_find_attr(node, "server");
 	autoconnect = xt_find_attr(node, "autoconnect");
 	tag = xt_find_attr(node, "tag");
+	locked = xt_find_attr(node, "locked");
 
 	protocol = xt_find_attr(node, "protocol");
 	if (protocol) {
@@ -125,6 +126,9 @@ static xt_status handle_account(struct xt_node *node, gpointer data)
 		}
 		if (local) {
 			acc->flags |= ACC_FLAG_LOCAL;
+		}
+		if (locked && !g_strcasecmp(locked, "true")) {
+			acc->flags |= ACC_FLAG_LOCKED;
 		}
 	} else {
 		g_free(pass_cr);
@@ -318,6 +322,9 @@ struct xt_node *xml_generate(irc_t *irc)
 		xt_add_attr(cur, "tag", acc->tag);
 		if (acc->server && acc->server[0]) {
 			xt_add_attr(cur, "server", acc->server);
+		}
+		if (acc->flags & ACC_FLAG_LOCKED) {
+			xt_add_attr(cur, "locked", "true");
 		}
 
 		g_free(pass_b64);

--- a/storage_xml.c
+++ b/storage_xml.c
@@ -64,9 +64,11 @@ static void xml_init(void)
 static void handle_settings(struct xt_node *node, set_t **head)
 {
 	struct xt_node *c;
+	struct set *s;
 
 	for (c = node->children; (c = xt_find_node(c, "setting")); c = c->next) {
 		char *name = xt_find_attr(c, "name");
+		char *locked = xt_find_attr(c, "locked");
 
 		if (!name) {
 			continue;
@@ -79,6 +81,12 @@ static void handle_settings(struct xt_node *node, set_t **head)
 			}
 		}
 		set_setstr(head, name, c->text);
+		if (locked && !g_strcasecmp(locked, "true")) {
+			s = set_find(head, name);
+			if (s) {
+				s->flags |= SET_LOCKED;
+			}
+		}
 	}
 }
 
@@ -370,6 +378,9 @@ static void xml_generate_settings(struct xt_node *cur, set_t **head)
 			struct xt_node *xset;
 			xt_add_child(cur, xset = xt_new_node("setting", set->value, NULL));
 			xt_add_attr(xset, "name", set->key);
+			if (set->flags & SET_LOCKED) {
+				xt_add_attr(xset, "locked", "true");
+			}
 		}
 	}
 }


### PR DESCRIPTION
I operate a bitblee server that is locked down a bit more than normal. Not only
is registration disabled, the configs are also pregenerated (they actually come
from a different storage backend using ldap and mysql).

In this setup it is incredibly useful to be able to say "this part of the
settings may not change". Specifically, anything around authentication and the
addition/deletion of accounts needs to be locked down.

These two commits accomplish this in a configurable way:

- In the pregenerated configs, you can set an account to be locked by adding a
  locked="true" attribute. This disables changing the username/password/server
  and deleting the account
- A new configuration option is added to disable account creation.