### PR TITLE
Remove vestiges of storage_text

### DIFF
--- a/storage.c
+++ b/storage.c
@@ -28,7 +28,6 @@
 #define BITLBEE_CORE
 #include "bitlbee.h"
 
-extern storage_t storage_text;
 extern storage_t storage_xml;
 
 static GList *storage_backends = NULL;


### PR DESCRIPTION
It was removed in ba7d16f, but this remained.