### PR TITLE
Support for multiple authentication backends

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: c
 
 script:
- - ./configure --pam=1
+ - ./configure --pam=1 --ldap=1
  - make check
  - BITLBEE_SKYPE=plugin dpkg-buildpackage -uc -us -d
 
@@ -29,12 +29,13 @@ addons:
     - libpurple-dev
     - check
     - libpam0g-dev
+    - libldap2-dev
   coverity_scan:
     project:
       name: "bitlbee/bitlbee"
       description: "An IRC to other chat networks gateway"
     notification_email: dx@dxzone.com.ar
-    build_command_prepend: ./configure --otr=1 --debug=1 --pam=1
+    build_command_prepend: ./configure --otr=1 --debug=1 --pam=1 --ldap=1
     build_command: make
     branch_pattern: coverity_scan
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: c
 
 script:
- - ./configure
+ - ./configure --pam=1
  - make check
  - BITLBEE_SKYPE=plugin dpkg-buildpackage -uc -us -d
 
@@ -28,12 +28,13 @@ addons:
     - libevent-dev
     - libpurple-dev
     - check
+    - libpam0g-dev
   coverity_scan:
     project:
       name: "bitlbee/bitlbee"
       description: "An IRC to other chat networks gateway"
     notification_email: dx@dxzone.com.ar
-    build_command_prepend: ./configure --otr=1 --debug=1
+    build_command_prepend: ./configure --otr=1 --debug=1 --pam=1
     build_command: make
     branch_pattern: coverity_scan
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@
 -include Makefile.settings
 
 # Program variables
-objects = bitlbee.o dcc.o help.o ipc.o irc.o irc_im.o irc_cap.o irc_channel.o irc_commands.o irc_send.o irc_user.o irc_util.o nick.o $(OTR_BI) query.o root_commands.o set.o storage.o $(STORAGE_OBJS) unix.o conf.o log.o
+objects = bitlbee.o dcc.o help.o ipc.o irc.o irc_im.o irc_cap.o irc_channel.o irc_commands.o irc_send.o irc_user.o irc_util.o nick.o $(OTR_BI) query.o root_commands.o set.o storage.o $(STORAGE_OBJS) auth.o $(AUTH_OBJS) unix.o conf.o log.o
 headers = $(wildcard $(_SRCDIR_)*.h $(_SRCDIR_)lib/*.h $(_SRCDIR_)protocols/*.h)
 subdirs = lib protocols
 

--- a/auth.c
+++ b/auth.c
@@ -4,6 +4,9 @@
 #ifdef WITH_PAM
 extern auth_backend_t auth_pam;
 #endif
+#ifdef WITH_LDAP
+extern auth_backend_t auth_ldap;
+#endif
 
 GList *auth_init(const char *backend)
 {
@@ -12,6 +15,12 @@ GList *auth_init(const char *backend)
 #ifdef WITH_PAM
 	gl = g_list_append(gl, &auth_pam);
 	if (backend && !strcmp(backend, "pam")) {
+		ok = 1;
+	}
+#endif
+#ifdef WITH_LDAP
+	gl = g_list_append(gl, &auth_ldap);
+	if (backend && !strcmp(backend, "ldap")) {
 		ok = 1;
 	}
 #endif

--- a/auth.c
+++ b/auth.c
@@ -1,10 +1,20 @@
 #define BITLBEE_CORE
 #include "bitlbee.h"
 
+#ifdef WITH_PAM
+extern auth_backend_t auth_pam;
+#endif
+
 GList *auth_init(const char *backend)
 {
 	GList *gl = NULL;
 	int ok = backend ? 0 : 1;
+#ifdef WITH_PAM
+	gl = g_list_append(gl, &auth_pam);
+	if (backend && !strcmp(backend, "pam")) {
+		ok = 1;
+	}
+#endif
 
 	return ok ? gl : NULL;
 }

--- a/auth.c
+++ b/auth.c
@@ -1,0 +1,46 @@
+#define BITLBEE_CORE
+#include "bitlbee.h"
+
+GList *auth_init(const char *backend)
+{
+	GList *gl = NULL;
+	int ok = backend ? 0 : 1;
+
+	return ok ? gl : NULL;
+}
+
+storage_status_t auth_check_pass(irc_t *irc, const char *nick, const char *password)
+{
+	GList *gl;
+	storage_status_t status = storage_check_pass(irc, nick, password);
+
+	if (status == STORAGE_CHECK_BACKEND) {
+		for (gl = global.auth; gl; gl = gl->next) {
+			auth_backend_t *be = gl->data;
+			if (!strcmp(be->name, irc->auth_backend)) {
+				status = be->check_pass(nick, password);
+				break;
+			}
+		}
+	} else if (status == STORAGE_NO_SUCH_USER && global.conf->auth_backend) {
+		for (gl = global.auth; gl; gl = gl->next) {
+			auth_backend_t *be = gl->data;
+			if (!strcmp(be->name, global.conf->auth_backend)) {
+				status = be->check_pass(nick, password);
+				/* Save the user so storage_load will pick them up, similar to
+				 * what the register command would do */
+				if (status == STORAGE_OK) {
+					irc->auth_backend = g_strdup(global.conf->auth_backend);
+					storage_save(irc, (char *)password, 0);
+				}
+				break;
+			}
+		}
+	}
+
+	if (status == STORAGE_OK) {
+		irc_setpass(irc, password);
+	}
+
+	return status;
+}

--- a/auth.h
+++ b/auth.h
@@ -1,0 +1,13 @@
+#ifndef __BITLBEE_AUTH_H__
+#define __BITLBEE_AUTH_H__
+
+#include "storage.h"
+
+typedef struct {
+	const char *name;
+	storage_status_t (*check_pass)(const char *nick, const char *password);
+} auth_backend_t;
+
+GList *auth_init(const char *backend);
+storage_status_t auth_check_pass(irc_t *irc, const char *nick, const char *password);
+#endif

--- a/auth_ldap.c
+++ b/auth_ldap.c
@@ -1,0 +1,77 @@
+#define BITLBEE_CORE
+#define LDAP_DEPRECATED 1
+#include "bitlbee.h"
+#include <ldap.h>
+
+static storage_status_t ldap_check_pass(const char *nick, const char *password)
+{
+	LDAP *ldap;
+	LDAPMessage *msg, *entry;
+	char *dn = NULL;
+	char *filter;
+	char *attrs[1] = { NULL };
+	int ret, count;
+
+	if((ret = ldap_initialize(&ldap, NULL)) != LDAP_SUCCESS) {
+		log_message(LOGLVL_WARNING, "ldap_initialize failed: %s", ldap_err2string(ret));
+		return STORAGE_OTHER_ERROR;
+	}
+
+	/* First we do an anonymous bind to map uid=$nick to a DN*/
+	if((ret = ldap_simple_bind_s(ldap, NULL, NULL)) != LDAP_SUCCESS) {
+		ldap_unbind_s(ldap);
+		log_message(LOGLVL_WARNING, "Anonymous bind failed: %s", ldap_err2string(ret));
+		return STORAGE_OTHER_ERROR;
+	}
+
+
+	/* We search and process the result */
+	filter = g_strdup_printf("(uid=%s)", nick);
+	ret = ldap_search_ext_s(ldap, NULL, LDAP_SCOPE_SUBTREE, filter, attrs, 0, NULL, NULL, NULL, 1, &msg);
+	g_free(filter);
+
+	if(ret != LDAP_SUCCESS) {
+		ldap_unbind_s(ldap);
+		log_message(LOGLVL_WARNING, "uid search failed: %s", ldap_err2string(ret));
+		return STORAGE_OTHER_ERROR;
+	}
+
+	count = ldap_count_entries(ldap, msg);
+	if (count == -1) {
+		ldap_get_option(ldap, LDAP_OPT_ERROR_NUMBER, &ret);
+		ldap_msgfree(msg);
+		ldap_unbind_s(ldap);
+		log_message(LOGLVL_WARNING, "uid search failed: %s", ldap_err2string(ret));
+		return STORAGE_OTHER_ERROR;
+	}
+
+	if (!count) {
+		ldap_msgfree(msg);
+		ldap_unbind_s(ldap);
+		return STORAGE_NO_SUCH_USER;
+	}
+
+	entry = ldap_first_entry(ldap, msg);
+	dn = ldap_get_dn(ldap, entry);
+	ldap_msgfree(msg);
+
+	/* And now we bind as the user to authenticate */
+	ret = ldap_simple_bind_s(ldap, dn, password);
+	g_free(dn);
+	ldap_unbind_s(ldap);
+
+	switch (ret) {
+		case LDAP_SUCCESS:
+			return STORAGE_OK;
+		case LDAP_INVALID_CREDENTIALS:
+			return STORAGE_INVALID_PASSWORD;
+		default:
+			log_message(LOGLVL_WARNING, "Authenticated bind failed: %s", ldap_err2string(ret));
+			return STORAGE_OTHER_ERROR;
+	}
+}
+
+auth_backend_t auth_ldap = {
+	.name = "ldap",
+	.check_pass = ldap_check_pass,
+};

--- a/auth_pam.c
+++ b/auth_pam.c
@@ -1,0 +1,62 @@
+#define BITLBEE_CORE
+#include "bitlbee.h"
+#include <security/pam_appl.h>
+
+#define PAM_CHECK(x) do { \
+	ret = (x); \
+	if(ret != PAM_SUCCESS) { \
+		pam_func = #x; \
+		goto pam_error; \
+	} \
+} while(0)
+
+/* This function fills in the password when PAM asks for it */
+int pamconv(int num_msg, const struct pam_message **msg, struct pam_response **resp, void *appdata_ptr) {
+	int i;
+	struct pam_response *rsp = g_new0(struct pam_response, num_msg);
+
+	for (i = 0; i < num_msg; i++) {
+		rsp[i].resp = NULL;
+		rsp[i].resp_retcode = 0;
+		if (msg[i]->msg_style == PAM_PROMPT_ECHO_OFF) {
+			rsp[i].resp = g_strdup((char *)appdata_ptr);
+		}
+	}
+	*resp = rsp;
+	return PAM_SUCCESS;
+}
+
+static storage_status_t pam_check_pass(const char *nick, const char *password)
+{
+	int ret;
+	const struct pam_conv pamc = { pamconv, (void*) password };
+	pam_handle_t *pamh = NULL;
+	char *pam_func;
+
+	PAM_CHECK(pam_start("bitlbee", nick, &pamc, &pamh));
+	PAM_CHECK(pam_authenticate(pamh, PAM_DISALLOW_NULL_AUTHTOK));
+	PAM_CHECK(pam_acct_mgmt(pamh, 0));
+
+	pam_end(pamh, ret);
+	return STORAGE_OK;
+
+pam_error:
+	switch (ret) {
+		case PAM_AUTH_ERR:
+			pam_end(pamh, ret);
+			return STORAGE_INVALID_PASSWORD;
+		case PAM_USER_UNKNOWN:
+		case PAM_PERM_DENIED:
+			pam_end(pamh, ret);
+			return STORAGE_NO_SUCH_USER;
+		default:
+			log_message(LOGLVL_WARNING, "%s failed: %s", pam_func, pam_strerror(pamh, ret));
+			pam_end(pamh, ret);
+			return STORAGE_OTHER_ERROR;
+	}
+}
+
+auth_backend_t auth_pam = {
+	.name = "pam",
+	.check_pass = pam_check_pass,
+};

--- a/bitlbee.conf
+++ b/bitlbee.conf
@@ -65,6 +65,7 @@
 ##
 ## - storage (internal storage)
 ## - pam (Linux PAM authentication)
+## - ldap (LDAP server configured in the openldap settings)
 #
 # AuthBackend = storage
 #

--- a/bitlbee.conf
+++ b/bitlbee.conf
@@ -51,6 +51,19 @@
 ##
 # AuthMode = Open
 
+## AuthBackend
+##
+## By default, the authentication data for a user is stored in the storage
+## backend. If you want to authenticate against another authentication system
+## (e.g. ldap), you can specify that here.
+##
+## Beware that this disables password changes and causes passwords for the
+## accounts people create to be stored in plain text instead of encrypted with
+## their bitlbee password.
+#
+# AuthBackend = storage
+#
+
 ## AuthPassword
 ##
 ## Password the user should enter when logging into a closed BitlBee server.

--- a/bitlbee.conf
+++ b/bitlbee.conf
@@ -60,6 +60,11 @@
 ## Beware that this disables password changes and causes passwords for the
 ## accounts people create to be stored in plain text instead of encrypted with
 ## their bitlbee password.
+##
+## Currently available backends:
+##
+## - storage (internal storage)
+## - pam (Linux PAM authentication)
 #
 # AuthBackend = storage
 #

--- a/bitlbee.h
+++ b/bitlbee.h
@@ -132,6 +132,7 @@ extern "C" {
 #include "bee.h"
 #include "irc.h"
 #include "storage.h"
+#include "auth.h"
 #include "set.h"
 #include "nogaim.h"
 #include "commands.h"
@@ -153,6 +154,7 @@ typedef struct global {
 	char *conf_file;
 	conf_t *conf;
 	GList *storage; /* The first backend in the list will be used for saving */
+	GList *auth;    /* Authentication backends */
 	char *helpfile;
 	int restart;
 } global_t;

--- a/conf.c
+++ b/conf.c
@@ -54,6 +54,7 @@ conf_t *conf_load(int argc, char *argv[])
 	conf->migrate_storage = g_strsplit("text", ",", -1);
 	conf->runmode = RUNMODE_INETD;
 	conf->authmode = AUTHMODE_OPEN;
+	conf->auth_backend = NULL;
 	conf->auth_pass = NULL;
 	conf->oper_pass = NULL;
 	conf->allow_account_add = 1;
@@ -239,6 +240,13 @@ static int conf_loadini(conf_t *conf, char *file)
 					conf->authmode = AUTHMODE_CLOSED;
 				} else {
 					conf->authmode = AUTHMODE_OPEN;
+				}
+			} else if (g_strcasecmp(ini->key, "authbackend") == 0) {
+				if (g_strcasecmp(ini->value, "storage") == 0) {
+					conf->auth_backend = NULL;
+				} else {
+					fprintf(stderr, "Invalid %s value: %s\n", ini->key, ini->value);
+					return 0;
 				}
 			} else if (g_strcasecmp(ini->key, "authpassword") == 0) {
 				g_free(conf->auth_pass);

--- a/conf.c
+++ b/conf.c
@@ -244,6 +244,9 @@ static int conf_loadini(conf_t *conf, char *file)
 			} else if (g_strcasecmp(ini->key, "authbackend") == 0) {
 				if (g_strcasecmp(ini->value, "storage") == 0) {
 					conf->auth_backend = NULL;
+				} else if (g_strcasecmp(ini->value, "pam") == 0) {
+					g_free(conf->auth_backend);
+					conf->auth_backend = g_strdup(ini->value);
 				} else {
 					fprintf(stderr, "Invalid %s value: %s\n", ini->key, ini->value);
 					return 0;

--- a/conf.c
+++ b/conf.c
@@ -244,7 +244,8 @@ static int conf_loadini(conf_t *conf, char *file)
 			} else if (g_strcasecmp(ini->key, "authbackend") == 0) {
 				if (g_strcasecmp(ini->value, "storage") == 0) {
 					conf->auth_backend = NULL;
-				} else if (g_strcasecmp(ini->value, "pam") == 0) {
+				} else if (g_strcasecmp(ini->value, "pam") == 0 ||
+				         g_strcasecmp(ini->value, "ldap") == 0) {
 					g_free(conf->auth_backend);
 					conf->auth_backend = g_strdup(ini->value);
 				} else {

--- a/conf.h
+++ b/conf.h
@@ -36,6 +36,7 @@ typedef struct conf {
 	int verbose;
 	runmode_t runmode;
 	authmode_t authmode;
+	char *auth_backend;
 	char *auth_pass;
 	char *oper_pass;
 	int allow_account_add;

--- a/configure
+++ b/configure
@@ -628,6 +628,11 @@ for i in $STORAGES; do
 done
 echo "STORAGE_OBJS="$STORAGE_OBJS >> Makefile.settings
 
+authobjs=
+authlibs=
+echo AUTH_OBJS=$authobjs >> Makefile.settings
+echo EFLAGS+=$authlibs >> Makefile.settings
+
 if [ "$strip" = 0 ]; then
 	echo "STRIP=\# skip strip" >> Makefile.settings;
 else

--- a/configure
+++ b/configure
@@ -52,6 +52,7 @@ events=glib
 ssl=auto
 
 pam=0
+ldap=0
 
 pie=1
 
@@ -136,6 +137,7 @@ Option		Description				Default
 		(automatically disables other protocol modules)
 
 --pam=0/1	Disable/enable PAM authentication	$pam
+--ldap=0/1	Disable/enable LDAP authentication	$ldap
 
 --doc=0/1	Disable/enable help.txt generation	$doc
 --debug=0/1	Disable/enable debugging		$debug
@@ -644,6 +646,17 @@ else
 	echo '#define WITH_PAM' >> config.h
 	authobjs=$authobjs'auth_pam.o '
 	authlibs=$authlibs'-lpam '
+fi
+if [ "$ldap" = 0 ]; then
+	echo '#undef WITH_LDAP' >> config.h
+else
+	if ! echo '#include <ldap.h>' | $CC -E - >/dev/null 2>/dev/null; then
+		echo 'Cannot find libldap development libraries, aborting. (Install libldap2-dev?)'
+		exit 1
+	fi
+	echo '#define WITH_LDAP' >> config.h
+	authobjs=$authobjs'auth_ldap.o '
+	authlibs=$authlibs'-lldap '
 fi
 echo AUTH_OBJS=$authobjs >> Makefile.settings
 echo EFLAGS+=$authlibs >> Makefile.settings

--- a/configure
+++ b/configure
@@ -51,6 +51,8 @@ skype=0
 events=glib
 ssl=auto
 
+pam=0
+
 pie=1
 
 arch=$(uname -s)
@@ -132,6 +134,8 @@ Option		Description				Default
 
 --purple=0/1	Disable/enable libpurple support	$purple
 		(automatically disables other protocol modules)
+
+--pam=0/1	Disable/enable PAM authentication	$pam
 
 --doc=0/1	Disable/enable help.txt generation	$doc
 --debug=0/1	Disable/enable debugging		$debug
@@ -630,6 +634,17 @@ echo "STORAGE_OBJS="$STORAGE_OBJS >> Makefile.settings
 
 authobjs=
 authlibs=
+if [ "$pam" = 0 ]; then
+	echo '#undef WITH_PAM' >> config.h
+else
+	if ! echo '#include <security/pam_appl.h>' | $CC -E - >/dev/null 2>/dev/null; then
+		echo 'Cannot find libpam development libraries, aborting. (Install libpam0g-dev?)'
+		exit 1
+	fi
+	echo '#define WITH_PAM' >> config.h
+	authobjs=$authobjs'auth_pam.o '
+	authlibs=$authlibs'-lpam '
+fi
 echo AUTH_OBJS=$authobjs >> Makefile.settings
 echo EFLAGS+=$authlibs >> Makefile.settings
 

--- a/irc.h
+++ b/irc.h
@@ -91,6 +91,7 @@ typedef struct irc {
 	char *password; /* HACK: Used to save the user's password, but before
 	                   logging in, this may contain a password we should
 	                   send to identify after USER/NICK are received. */
+	char *auth_backend;
 
 	char umode[8];
 

--- a/irc_commands.c
+++ b/irc_commands.c
@@ -96,7 +96,7 @@ static gboolean irc_sasl_check_pass(irc_t *irc, char *user, char *pass)
 
 	/* just check the password here to be able to reply with useful numerics
 	 * the actual identification will be handled later */
-	status = storage_check_pass(user, pass);
+	status = auth_check_pass(irc, user, pass);
 
 	if (status == STORAGE_OK) {
 		if (!irc->user->nick) {

--- a/root_commands.c
+++ b/root_commands.c
@@ -142,10 +142,9 @@ static void cmd_identify(irc_t *irc, char **cmd)
 		return;
 	}
 
-	if (load) {
+	status = auth_check_pass(irc, irc->user->nick, password);
+	if (load && (status == STORAGE_OK)) {
 		status = storage_load(irc, password);
-	} else {
-		status = storage_check_pass(irc->user->nick, password);
 	}
 
 	switch (status) {
@@ -158,7 +157,6 @@ static void cmd_identify(irc_t *irc, char **cmd)
 	case STORAGE_OK:
 		irc_rootmsg(irc, "Password accepted%s",
 		            load ? ", settings and accounts loaded" : "");
-		irc_setpass(irc, password);
 		irc->status |= USTATUS_IDENTIFIED;
 		irc_umode_set(irc, "+R", 1);
 
@@ -267,7 +265,11 @@ static void cmd_drop(irc_t *irc, char **cmd)
 {
 	storage_status_t status;
 
-	status = storage_remove(irc->user->nick, cmd[1]);
+	status = auth_check_pass(irc, irc->user->nick, cmd[1]);
+	if (status == STORAGE_OK) {
+		status = storage_remove(irc->user->nick);
+	}
+
 	switch (status) {
 	case STORAGE_NO_SUCH_USER:
 		irc_rootmsg(irc, "That account does not exist");

--- a/storage.c
+++ b/storage.c
@@ -86,7 +86,7 @@ GList *storage_init(const char *primary, char **migrate)
 	return ret;
 }
 
-storage_status_t storage_check_pass(const char *nick, const char *password)
+storage_status_t storage_check_pass(irc_t *irc, const char *nick, const char *password)
 {
 	GList *gl;
 
@@ -96,7 +96,7 @@ storage_status_t storage_check_pass(const char *nick, const char *password)
 		storage_t *st = gl->data;
 		storage_status_t status;
 
-		status = st->check_pass(nick, password);
+		status = st->check_pass(irc, nick, password);
 		if (status != STORAGE_NO_SUCH_USER) {
 			return status;
 		}
@@ -170,7 +170,7 @@ storage_status_t storage_save(irc_t *irc, char *password, int overwrite)
 	return st;
 }
 
-storage_status_t storage_remove(const char *nick, const char *password)
+storage_status_t storage_remove(const char *nick)
 {
 	GList *gl;
 	storage_status_t ret = STORAGE_OK;
@@ -184,7 +184,7 @@ storage_status_t storage_remove(const char *nick, const char *password)
 		storage_t *st = gl->data;
 		storage_status_t status;
 
-		status = st->remove(nick, password);
+		status = st->remove(nick);
 		ok |= status == STORAGE_OK;
 		if (status != STORAGE_NO_SUCH_USER && status != STORAGE_OK) {
 			ret = status;

--- a/storage.h
+++ b/storage.h
@@ -30,6 +30,7 @@ typedef enum {
 	STORAGE_OK = 0,
 	STORAGE_NO_SUCH_USER,
 	STORAGE_INVALID_PASSWORD,
+	STORAGE_CHECK_BACKEND,
 	STORAGE_ALREADY_EXISTS,
 	STORAGE_OTHER_ERROR /* Error that isn't caused by user input, such as
 	                       a database that is unreachable. log() will be
@@ -42,21 +43,21 @@ typedef struct {
 	/* May be set to NULL if not required */
 	void (*init)(void);
 
-	storage_status_t (*check_pass)(const char *nick, const char *password);
+	storage_status_t (*check_pass)(irc_t *irc, const char *nick, const char *password);
 
 	storage_status_t (*load)(irc_t *irc, const char *password);
 	storage_status_t (*save)(irc_t *irc, int overwrite);
-	storage_status_t (*remove)(const char *nick, const char *password);
+	storage_status_t (*remove)(const char *nick);
 
 	/* May be NULL if not supported by backend */
 	storage_status_t (*rename)(const char *onick, const char *nnick, const char *password);
 } storage_t;
 
-storage_status_t storage_check_pass(const char *nick, const char *password);
+storage_status_t storage_check_pass(irc_t *irc, const char *nick, const char *password);
 
 storage_status_t storage_load(irc_t * irc, const char *password);
 storage_status_t storage_save(irc_t *irc, char *password, int overwrite);
-storage_status_t storage_remove(const char *nick, const char *password);
+storage_status_t storage_remove(const char *nick);
 
 void register_storage_backend(storage_t *);
 G_GNUC_MALLOC GList *storage_init(const char *primary, char **migrate);

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -14,7 +14,7 @@ clean:
 
 distclean: clean
 
-main_objs = bitlbee.o conf.o dcc.o help.o ipc.o irc.o irc_cap.o irc_channel.o irc_commands.o irc_im.o irc_send.o irc_user.o irc_util.o irc_commands.o log.o nick.o query.o root_commands.o set.o storage.o storage_xml.o auth.o auth_pam.o
+main_objs = bitlbee.o conf.o dcc.o help.o ipc.o irc.o irc_cap.o irc_channel.o irc_commands.o irc_im.o irc_send.o irc_user.o irc_util.o irc_commands.o log.o nick.o query.o root_commands.o set.o storage.o storage_xml.o auth.o auth_pam.o auth_ldap.o
 
 test_objs = check.o check_util.o check_nick.o check_md5.o check_arc.o check_irc.o check_help.o check_user.o check_set.o check_jabber_sasl.o check_jabber_util.o
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -14,7 +14,7 @@ clean:
 
 distclean: clean
 
-main_objs = bitlbee.o conf.o dcc.o help.o ipc.o irc.o irc_cap.o irc_channel.o irc_commands.o irc_im.o irc_send.o irc_user.o irc_util.o irc_commands.o log.o nick.o query.o root_commands.o set.o storage.o storage_xml.o
+main_objs = bitlbee.o conf.o dcc.o help.o ipc.o irc.o irc_cap.o irc_channel.o irc_commands.o irc_im.o irc_send.o irc_user.o irc_util.o irc_commands.o log.o nick.o query.o root_commands.o set.o storage.o storage_xml.o auth.o
 
 test_objs = check.o check_util.o check_nick.o check_md5.o check_arc.o check_irc.o check_help.o check_user.o check_set.o check_jabber_sasl.o check_jabber_util.o
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -14,7 +14,7 @@ clean:
 
 distclean: clean
 
-main_objs = bitlbee.o conf.o dcc.o help.o ipc.o irc.o irc_cap.o irc_channel.o irc_commands.o irc_im.o irc_send.o irc_user.o irc_util.o irc_commands.o log.o nick.o query.o root_commands.o set.o storage.o storage_xml.o auth.o
+main_objs = bitlbee.o conf.o dcc.o help.o ipc.o irc.o irc_cap.o irc_channel.o irc_commands.o irc_im.o irc_send.o irc_user.o irc_util.o irc_commands.o log.o nick.o query.o root_commands.o set.o storage.o storage_xml.o auth.o auth_pam.o
 
 test_objs = check.o check_util.o check_nick.o check_md5.o check_arc.o check_irc.o check_help.o check_user.o check_set.o check_jabber_sasl.o check_jabber_util.o
 

--- a/unix.c
+++ b/unix.c
@@ -103,6 +103,12 @@ int main(int argc, char *argv[])
 		return(1);
 	}
 
+	global.auth = auth_init(global.conf->auth_backend);
+	if (global.conf->auth_backend && global.auth == NULL) {
+		log_message(LOGLVL_ERROR, "Unable to load authentication backend '%s'", global.conf->auth_backend);
+		return(1);
+	}
+
 	if (global.conf->runmode == RUNMODE_INETD) {
 		log_link(LOGLVL_ERROR, LOGOUTPUT_IRC);
 		log_link(LOGLVL_WARNING, LOGOUTPUT_IRC);


### PR DESCRIPTION
As with PR #61, these patches are driven by my need to operate bitlbee in an
enterprise situation. Integrating with existing authentication solutions is
important there.

This is a 3-patch series that adds two authentication backends and the
infrastructure to easily add more. The infrastructure to do that is inspired by
(but not an exact copy of) the existing storage backend infrastructure.

More details about the changes are in the commits themselves, especially in the
first one.

As both authentication backends require extra libraries and development
headers, they are both optional and bitlbee works as normal without them. Even
with the authentication backends compiled in, they're not used by default and
bitlbee works teh same as now.