### PR TITLE
Mysql storage backend [do not merge in current form]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: c
 
 script:
- - ./configure --pam=1
+ - ./configure --pam=1 --ldap=1
  - make check
  - BITLBEE_SKYPE=plugin dpkg-buildpackage -uc -us -d
 
@@ -29,12 +29,13 @@ addons:
     - libpurple-dev
     - check
     - libpam0g-dev
+    - libldap2-dev
   coverity_scan:
     project:
       name: "bitlbee/bitlbee"
       description: "An IRC to other chat networks gateway"
     notification_email: dx@dxzone.com.ar
-    build_command_prepend: ./configure --otr=1 --debug=1 --pam=1
+    build_command_prepend: ./configure --otr=1 --debug=1 --pam=1 --ldap=1
     build_command: make
     branch_pattern: coverity_scan
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: c
 
 script:
- - ./configure
+ - ./configure --pam=1
  - make check
  - BITLBEE_SKYPE=plugin dpkg-buildpackage -uc -us -d
 
@@ -28,12 +28,13 @@ addons:
     - libevent-dev
     - libpurple-dev
     - check
+    - libpam0g-dev
   coverity_scan:
     project:
       name: "bitlbee/bitlbee"
       description: "An IRC to other chat networks gateway"
     notification_email: dx@dxzone.com.ar
-    build_command_prepend: ./configure --otr=1 --debug=1
+    build_command_prepend: ./configure --otr=1 --debug=1 --pam=1
     build_command: make
     branch_pattern: coverity_scan
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ addons:
     - check
     - libpam0g-dev
     - libldap2-dev
+    - libmysqlclient-dev
   coverity_scan:
     project:
       name: "bitlbee/bitlbee"

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@
 -include Makefile.settings
 
 # Program variables
-objects = bitlbee.o dcc.o help.o ipc.o irc.o irc_im.o irc_cap.o irc_channel.o irc_commands.o irc_send.o irc_user.o irc_util.o nick.o $(OTR_BI) query.o root_commands.o set.o storage.o $(STORAGE_OBJS) unix.o conf.o log.o
+objects = bitlbee.o dcc.o help.o ipc.o irc.o irc_im.o irc_cap.o irc_channel.o irc_commands.o irc_send.o irc_user.o irc_util.o nick.o $(OTR_BI) query.o root_commands.o set.o storage.o $(STORAGE_OBJS) auth.o $(AUTH_OBJS) unix.o conf.o log.o
 headers = $(wildcard $(_SRCDIR_)*.h $(_SRCDIR_)lib/*.h $(_SRCDIR_)protocols/*.h)
 subdirs = lib protocols
 

--- a/auth.c
+++ b/auth.c
@@ -1,10 +1,19 @@
 #define BITLBEE_CORE
 #include "bitlbee.h"
 
+#ifdef WITH_PAM
+extern auth_backend_t auth_pam;
+#endif
+
 GList *auth_init(const char *backend)
 {
 	GList *gl = NULL;
 	int ok = backend ? 0 : 1;
+#ifdef WITH_PAM
+	gl = g_list_append(gl, &auth_pam);
+	if (backend && !strcmp(backend, "pam"))
+		ok = 1;
+#endif
 
 	return ok ? gl : NULL;
 }

--- a/auth.c
+++ b/auth.c
@@ -1,0 +1,21 @@
+#define BITLBEE_CORE
+#include "bitlbee.h"
+
+GList *auth_init(const char *backend)
+{
+	GList *gl = NULL;
+	int ok = backend ? 0 : 1;
+
+	return ok ? gl : NULL;
+}
+
+storage_status_t auth_check_pass(const char *backend, const char *nick, const char *password)
+{
+	GList *gl;
+	for (gl = global.auth; gl; gl = gl->next) {
+		auth_backend_t *be = gl->data;
+		if (!strcmp(be->name, backend))
+			return be->check_pass(nick, password);
+	}
+	return STORAGE_OTHER_ERROR;
+}

--- a/auth.c
+++ b/auth.c
@@ -4,6 +4,9 @@
 #ifdef WITH_PAM
 extern auth_backend_t auth_pam;
 #endif
+#ifdef WITH_LDAP
+extern auth_backend_t auth_ldap;
+#endif
 
 GList *auth_init(const char *backend)
 {
@@ -12,6 +15,11 @@ GList *auth_init(const char *backend)
 #ifdef WITH_PAM
 	gl = g_list_append(gl, &auth_pam);
 	if (backend && !strcmp(backend, "pam"))
+		ok = 1;
+#endif
+#ifdef WITH_LDAP
+	gl = g_list_append(gl, &auth_ldap);
+	if (backend && !strcmp(backend, "ldap"))
 		ok = 1;
 #endif
 

--- a/auth.h
+++ b/auth.h
@@ -1,0 +1,13 @@
+#ifndef __BITLBEE_AUTH_H__
+#define __BITLBEE_AUTH_H__
+
+#include "storage.h"
+
+typedef struct {
+	const char *name;
+	storage_status_t (*check_pass)(const char *nick, const char *password);
+} auth_backend_t;
+
+GList *auth_init(const char *backend);
+storage_status_t auth_check_pass(const char *backend, const char *nick, const char *password);
+#endif

--- a/auth_ldap.c
+++ b/auth_ldap.c
@@ -1,0 +1,77 @@
+#define BITLBEE_CORE
+#define LDAP_DEPRECATED 1
+#include "bitlbee.h"
+#include <ldap.h>
+
+static storage_status_t ldap_check_pass(const char *nick, const char *password)
+{
+	LDAP *ldap;
+	LDAPMessage *msg, *entry;
+	char *dn = NULL;
+	char *filter;
+	char *attrs[1] = { NULL };
+	int ret, count;
+
+	if((ret = ldap_initialize(&ldap, NULL)) != LDAP_SUCCESS) {
+		log_message(LOGLVL_WARNING, "ldap_initialize failed: %s", ldap_err2string(ret));
+		return STORAGE_OTHER_ERROR;
+	}
+
+	/* First we do an anonymous bind to map uid=$nick to a DN*/
+	if((ret = ldap_simple_bind_s(ldap, NULL, NULL)) != LDAP_SUCCESS) {
+		ldap_unbind_s(ldap);
+		log_message(LOGLVL_WARNING, "Anonymous bind failed: %s", ldap_err2string(ret));
+		return STORAGE_OTHER_ERROR;
+	}
+
+
+	/* We search and process the result */
+	filter = g_strdup_printf("(uid=%s)", nick);
+	ret = ldap_search_ext_s(ldap, NULL, LDAP_SCOPE_SUBTREE, filter, attrs, 0, NULL, NULL, NULL, 1, &msg);
+	g_free(filter);
+
+	if(ret != LDAP_SUCCESS) {
+		ldap_unbind_s(ldap);
+		log_message(LOGLVL_WARNING, "uid search failed: %s", ldap_err2string(ret));
+		return STORAGE_OTHER_ERROR;
+	}
+
+	count = ldap_count_entries(ldap, msg);
+	if (count == -1) {
+		ldap_get_option(ldap, LDAP_OPT_ERROR_NUMBER, &ret);
+		ldap_msgfree(msg);
+		ldap_unbind_s(ldap);
+		log_message(LOGLVL_WARNING, "uid search failed: %s", ldap_err2string(ret));
+		return STORAGE_OTHER_ERROR;
+	}
+
+	if (!count) {
+		ldap_msgfree(msg);
+		ldap_unbind_s(ldap);
+		return STORAGE_NO_SUCH_USER;
+	}
+
+	entry = ldap_first_entry(ldap, msg);
+	dn = ldap_get_dn(ldap, entry);
+	ldap_msgfree(msg);
+
+	/* And now we bind as the user to authenticate */
+	ret = ldap_simple_bind_s(ldap, dn, password);
+	g_free(dn);
+	ldap_unbind_s(ldap);
+
+	switch (ret) {
+		case LDAP_SUCCESS:
+			return STORAGE_OK;
+		case LDAP_INVALID_CREDENTIALS:
+			return STORAGE_INVALID_PASSWORD;
+		default:
+			log_message(LOGLVL_WARNING, "Authenticated bind failed: %s", ldap_err2string(ret));
+			return STORAGE_OTHER_ERROR;
+	}
+}
+
+auth_backend_t auth_ldap = {
+	.name = "ldap",
+	.check_pass = ldap_check_pass,
+};

--- a/auth_pam.c
+++ b/auth_pam.c
@@ -1,0 +1,62 @@
+#define BITLBEE_CORE
+#include "bitlbee.h"
+#include <security/pam_appl.h>
+
+#define PAM_CHECK(x) do { \
+	ret = (x); \
+	if(ret != PAM_SUCCESS) { \
+		pam_func = #x; \
+		goto pam_error; \
+	} \
+} while(0)
+
+/* This function fills in the password when PAM asks for it */
+int pamconv(int num_msg, const struct pam_message **msg, struct pam_response **resp, void *appdata_ptr) {
+	int i;
+	struct pam_response *rsp = g_new0(struct pam_response, num_msg);
+
+	for (i = 0; i < num_msg; i++) {
+		rsp[i].resp = NULL;
+		rsp[i].resp_retcode = 0;
+		if (msg[i]->msg_style == PAM_PROMPT_ECHO_OFF) {
+			rsp[i].resp = g_strdup((char *)appdata_ptr);
+		}
+	}
+	*resp = rsp;
+	return PAM_SUCCESS;
+}
+
+static storage_status_t pam_check_pass(const char *nick, const char *password)
+{
+	int ret;
+	const struct pam_conv pamc = { pamconv, (void*) password };
+	pam_handle_t *pamh = NULL;
+	char *pam_func;
+
+	PAM_CHECK(pam_start("bitlbee", nick, &pamc, &pamh));
+	PAM_CHECK(pam_authenticate(pamh, PAM_DISALLOW_NULL_AUTHTOK));
+	PAM_CHECK(pam_acct_mgmt(pamh, 0));
+
+	pam_end(pamh, ret);
+	return STORAGE_OK;
+
+pam_error:
+	switch (ret) {
+		case PAM_AUTH_ERR:
+			pam_end(pamh, ret);
+			return STORAGE_INVALID_PASSWORD;
+		case PAM_USER_UNKNOWN:
+		case PAM_PERM_DENIED:
+			pam_end(pamh, ret);
+			return STORAGE_NO_SUCH_USER;
+		default:
+			log_message(LOGLVL_WARNING, "%s failed: %s", pam_func, pam_strerror(pamh, ret));
+			pam_end(pamh, ret);
+			return STORAGE_OTHER_ERROR;
+	}
+}
+
+auth_backend_t auth_pam = {
+	.name = "pam",
+	.check_pass = pam_check_pass,
+};

--- a/bitlbee.conf
+++ b/bitlbee.conf
@@ -110,6 +110,15 @@
 ##
 # MotdFile = /etc/bitlbee/motd.txt
 
+## AccountStorage
+##
+## By default, BitlBee stores all account data in XML files in the ConfigDir
+## specified below. It can also store data in a MySQL database. To specify a
+## location for this database, create /etc/bitlbee/my.cnf with connection and
+## database information.
+##
+# AccountStorage = xml
+
 ## ConfigDir
 ##
 ## Specify an alternative directory to store all the per-user configuration

--- a/bitlbee.conf
+++ b/bitlbee.conf
@@ -88,6 +88,13 @@
 ## or
 # OperPassword = md5:I0mnZbn1t4R731zzRdDN2/pK7lRX
 
+## AllowAccountAdd
+##
+## Whether to allow registered and identified users to add new accounts using
+## 'account add'
+##
+# AllowAccountAdd 1
+
 ## HostName
 ##
 ## Normally, BitlBee gets a hostname using getsockname(). If you have a nicer

--- a/bitlbee.conf
+++ b/bitlbee.conf
@@ -65,6 +65,7 @@
 ##
 ## - storage (internal storage)
 ## - pam (Linux PAM authentication)
+## - ldap (LDAP server configured in the openldap settings)
 #
 # AuthBackend = storage
 #

--- a/bitlbee.conf
+++ b/bitlbee.conf
@@ -51,6 +51,19 @@
 ##
 # AuthMode = Open
 
+## AuthBackend
+##
+## By default, the authentication data for a user is stored in the storage
+## backend. If you want to authenticate against another authentication system
+## (e.g. ldap), you can specify that here.
+##
+## Beware that this disables password changes and causes passwords for the
+## accounts people create to be stored in plain text instead of encrypted with
+## their bitlbee password.
+#
+# AuthBackend = storage
+#
+
 ## AuthPassword
 ##
 ## Password the user should enter when logging into a closed BitlBee server.

--- a/bitlbee.conf
+++ b/bitlbee.conf
@@ -60,6 +60,11 @@
 ## Beware that this disables password changes and causes passwords for the
 ## accounts people create to be stored in plain text instead of encrypted with
 ## their bitlbee password.
+##
+## Currently available backends:
+##
+## - storage (internal storage)
+## - pam (Linux PAM authentication)
 #
 # AuthBackend = storage
 #

--- a/bitlbee.h
+++ b/bitlbee.h
@@ -132,6 +132,7 @@ extern "C" {
 #include "bee.h"
 #include "irc.h"
 #include "storage.h"
+#include "auth.h"
 #include "set.h"
 #include "nogaim.h"
 #include "commands.h"
@@ -153,6 +154,7 @@ typedef struct global {
 	char *conf_file;
 	conf_t *conf;
 	GList *storage; /* The first backend in the list will be used for saving */
+	GList *auth;    /* Authentication backends */
 	char *helpfile;
 	int restart;
 } global_t;

--- a/bitlbee.h
+++ b/bitlbee.h
@@ -145,6 +145,7 @@ extern "C" {
 #include "sock.h"
 #include "misc.h"
 #include "proxy.h"
+#include "password.h"
 
 typedef struct global {
 	/* In forked mode, child processes store the fd of the IPC socket here. */

--- a/conf.c
+++ b/conf.c
@@ -243,7 +243,8 @@ static int conf_loadini(conf_t *conf, char *file)
 			} else if (g_strcasecmp(ini->key, "authbackend") == 0) {
 				if (g_strcasecmp(ini->value, "storage") == 0) {
 					conf->auth_backend = NULL;
-				} else if (g_strcasecmp(ini->value, "pam") == 0) {
+				} else if (g_strcasecmp(ini->value, "pam") == 0 ||
+				         g_strcasecmp(ini->value, "ldap") == 0) {
 					g_free(conf->auth_backend);
 					conf->auth_backend = g_strdup(ini->value);
 				} else {

--- a/conf.c
+++ b/conf.c
@@ -54,6 +54,7 @@ conf_t *conf_load(int argc, char *argv[])
 	conf->migrate_storage = g_strsplit("text", ",", -1);
 	conf->runmode = RUNMODE_INETD;
 	conf->authmode = AUTHMODE_OPEN;
+	conf->auth_backend = NULL;
 	conf->auth_pass = NULL;
 	conf->oper_pass = NULL;
 	conf->configdir = g_strdup(CONFIG);
@@ -238,6 +239,13 @@ static int conf_loadini(conf_t *conf, char *file)
 					conf->authmode = AUTHMODE_CLOSED;
 				} else {
 					conf->authmode = AUTHMODE_OPEN;
+				}
+			} else if (g_strcasecmp(ini->key, "authbackend") == 0) {
+				if (g_strcasecmp(ini->value, "storage") == 0) {
+					conf->auth_backend = NULL;
+				} else {
+					fprintf(stderr, "Invalid %s value: %s\n", ini->key, ini->value);
+					return 0;
 				}
 			} else if (g_strcasecmp(ini->key, "authpassword") == 0) {
 				g_free(conf->auth_pass);

--- a/conf.c
+++ b/conf.c
@@ -243,6 +243,9 @@ static int conf_loadini(conf_t *conf, char *file)
 			} else if (g_strcasecmp(ini->key, "authbackend") == 0) {
 				if (g_strcasecmp(ini->value, "storage") == 0) {
 					conf->auth_backend = NULL;
+				} else if (g_strcasecmp(ini->value, "pam") == 0) {
+					g_free(conf->auth_backend);
+					conf->auth_backend = g_strdup(ini->value);
 				} else {
 					fprintf(stderr, "Invalid %s value: %s\n", ini->key, ini->value);
 					return 0;

--- a/conf.c
+++ b/conf.c
@@ -57,6 +57,7 @@ conf_t *conf_load(int argc, char *argv[])
 	conf->auth_backend = NULL;
 	conf->auth_pass = NULL;
 	conf->oper_pass = NULL;
+	conf->allow_account_add = 1;
 	conf->configdir = g_strdup(CONFIG);
 	conf->plugindir = g_strdup(PLUGINDIR);
 	conf->pidfile = g_strdup(PIDFILE);
@@ -257,6 +258,12 @@ static int conf_loadini(conf_t *conf, char *file)
 			} else if (g_strcasecmp(ini->key, "operpassword") == 0) {
 				g_free(conf->oper_pass);
 				conf->oper_pass = g_strdup(ini->value);
+			} else if (g_strcasecmp(ini->key, "allowaccountadd") == 0) {
+				if (sscanf(ini->value, "%d", &i) != 1) {
+					fprintf(stderr, "Invalid %s value: %s\n", ini->key, ini->value);
+					return 0;
+				}
+				conf->allow_account_add = !!i;
 			} else if (g_strcasecmp(ini->key, "hostname") == 0) {
 				g_free(conf->hostname);
 				conf->hostname = g_strdup(ini->value);

--- a/conf.c
+++ b/conf.c
@@ -276,7 +276,7 @@ static int conf_loadini(conf_t *conf, char *file)
 			} else if (g_strcasecmp(ini->key, "motdfile") == 0) {
 				g_free(conf->motdfile);
 				conf->motdfile = g_strdup(ini->value);
-			} else if (g_strcasecmp(ini->key, "account_storage") == 0) {
+			} else if (g_strcasecmp(ini->key, "accountstorage") == 0) {
 				g_free(conf->primary_storage);
 				conf->primary_storage = g_strdup(ini->value);
 			} else if (g_strcasecmp(ini->key, "account_storage_migrate") == 0) {

--- a/conf.h
+++ b/conf.h
@@ -36,6 +36,7 @@ typedef struct conf {
 	int verbose;
 	runmode_t runmode;
 	authmode_t authmode;
+	char *auth_backend;
 	char *auth_pass;
 	char *oper_pass;
 	char *hostname;

--- a/conf.h
+++ b/conf.h
@@ -39,6 +39,7 @@ typedef struct conf {
 	char *auth_backend;
 	char *auth_pass;
 	char *oper_pass;
+	int allow_account_add;
 	char *hostname;
 	char *configdir;
 	char *plugindir;

--- a/configure
+++ b/configure
@@ -628,6 +628,11 @@ for i in $STORAGES; do
 done
 echo "STORAGE_OBJS="$STORAGE_OBJS >> Makefile.settings
 
+authobjs=
+authlibs=
+echo AUTH_OBJS=$authobjs >> Makefile.settings
+echo EFLAGS+=$authlibs >> Makefile.settings
+
 if [ "$strip" = 0 ]; then
 	echo "STRIP=\# skip strip" >> Makefile.settings;
 else

--- a/configure
+++ b/configure
@@ -52,6 +52,7 @@ events=glib
 ssl=auto
 
 pam=0
+ldap=0
 
 pie=1
 
@@ -136,6 +137,7 @@ Option		Description				Default
 		(automatically disables other protocol modules)
 
 --pam=0/1	Disable/enable PAM authentication	$pam
+--ldap=0/1	Disable/enable LDAP authentication	$ldap
 
 --doc=0/1	Disable/enable help.txt generation	$doc
 --debug=0/1	Disable/enable debugging		$debug
@@ -644,6 +646,17 @@ else
 	echo '#define WITH_PAM' >> config.h
 	authobjs=$authobjs'auth_pam.o '
 	authlibs=$authlibs'-lpam '
+fi
+if [ "$ldap" = 0 ]; then
+	echo '#undef WITH_LDAP' >> config.h
+else
+	if ! echo '#include <ldap.h>' | $CC -E - >/dev/null 2>/dev/null; then
+		echo 'Cannot find libldap development libraries, aborting. (Install libldap2-dev?)'
+		exit 1
+	fi
+	echo '#define WITH_LDAP' >> config.h
+	authobjs=$authobjs'auth_ldap.o '
+	authlibs=$authlibs'-lldap '
 fi
 echo AUTH_OBJS=$authobjs >> Makefile.settings
 echo EFLAGS+=$authlibs >> Makefile.settings

--- a/configure
+++ b/configure
@@ -629,6 +629,16 @@ fi
 
 STORAGES="xml"
 
+if mysql_config --libs >/dev/null 2>/dev/null; then
+	if echo '#include <ldap.h>' | cpp >/dev/null 2>/dev/null; then
+		echo "CFLAGS+=$(mysql_config --cflags)" >> Makefile.settings
+		echo "EFLAGS+=$(mysql_config --libs)" >> Makefile.settings
+		echo "EFLAGS+=-lldap" >> Makefile.settings
+		echo "#define WITH_MYSQL" >> config.h
+		STORAGES="$STORAGES mysql"
+	fi
+fi
+
 for i in $STORAGES; do
 	STORAGE_OBJS="$STORAGE_OBJS storage_$i.o"
 done
@@ -963,7 +973,7 @@ fi
 
 echo '  Using event handler: '$events
 echo '  Using SSL library: '$ssl
-#echo '  Building with these storage backends: '$STORAGES
+echo '  Building with these storage backends: '$STORAGES
 
 if [ -n "$protocols" ]; then
 	echo '  Building with these protocols:' $protocols$protocols_mods

--- a/configure
+++ b/configure
@@ -51,6 +51,8 @@ skype=0
 events=glib
 ssl=auto
 
+pam=0
+
 pie=1
 
 arch=$(uname -s)
@@ -132,6 +134,8 @@ Option		Description				Default
 
 --purple=0/1	Disable/enable libpurple support	$purple
 		(automatically disables other protocol modules)
+
+--pam=0/1	Disable/enable PAM authentication	$pam
 
 --doc=0/1	Disable/enable help.txt generation	$doc
 --debug=0/1	Disable/enable debugging		$debug
@@ -630,6 +634,17 @@ echo "STORAGE_OBJS="$STORAGE_OBJS >> Makefile.settings
 
 authobjs=
 authlibs=
+if [ "$pam" = 0 ]; then
+	echo '#undef WITH_PAM' >> config.h
+else
+	if ! echo '#include <security/pam_appl.h>' | $CC -E - >/dev/null 2>/dev/null; then
+		echo 'Cannot find libpam development libraries, aborting. (Install libpam0g-dev?)'
+		exit 1
+	fi
+	echo '#define WITH_PAM' >> config.h
+	authobjs=$authobjs'auth_pam.o '
+	authlibs=$authlibs'-lpam '
+fi
 echo AUTH_OBJS=$authobjs >> Makefile.settings
 echo EFLAGS+=$authlibs >> Makefile.settings
 

--- a/doc/bitlbee_schema.sql
+++ b/doc/bitlbee_schema.sql
@@ -1,0 +1,59 @@
+-- This is the schema used by BitlBee's MySQL storage backend
+
+CREATE TABLE users (
+    `login`          VARCHAR(32) NOT NULL,
+    `password`       VARCHAR(128) NOT NULL,
+    `auth_backend`   VARCHAR(64) NOT NULL,
+    PRIMARY KEY (`login`)
+);
+
+CREATE TABLE settings (
+    `login`   VARCHAR(32) NOT NULL,
+    `setting` VARCHAR(32) NOT NULL,
+    `value`   VARCHAR(64) NOT NULL,
+    `locked`  TINYINT(1) NOT NULL DEFAULT 0,
+    PRIMARY KEY (`login`, `setting`),
+    INDEX `login` (`login`)
+);
+
+CREATE TABLE accounts (
+    `login`        VARCHAR(32) NOT NULL,
+    `account`      VARCHAR(64) NOT NULL,
+    `protocol`     VARCHAR(16) NOT NULL,
+    `password`     VARCHAR(128) NOT NULL,
+    `tag`          VARCHAR(32) NOT NULL,
+    `server`       VARCHAR(64) NOT NULL DEFAULT "",
+    `auto_connect` TINYINT(1) NOT NULL DEFAULT 0,
+    `locked`       TINYINT(1) NOT NULL DEFAULT 0,
+    PRIMARY KEY (`login`, `account`),
+    INDEX `login` (`login`)
+);
+
+CREATE TABLE account_settings (
+    `login`   VARCHAR(32) NOT NULL,
+    `account` VARCHAR(64) NOT NULL,
+    `setting` VARCHAR(32) NOT NULL,
+    `value`   VARCHAR(64) NOT NULL,
+    `locked`  TINYINT(1) NOT NULL DEFAULT 0,
+    PRIMARY KEY (`login`, `account`, `setting`),
+    INDEX `login` (`login`, `account`)
+);
+
+CREATE TABLE channel_settings (
+    `login`   VARCHAR(32) NOT NULL,
+    `channel` VARCHAR(64) NOT NULL,
+    `setting` VARCHAR(32) NOT NULL,
+    `value`   VARCHAR(64) NOT NULL,
+    `locked`  TINYINT(1) NOT NULL DEFAULT 0,
+    PRIMARY KEY (`login`, `channel`, `setting`),
+    INDEX `login` (`login`)
+);
+
+CREATE TABLE buddies (
+    `login`  VARCHAR(32) NOT NULL,
+    `account`VARCHAR(64) NOT NULL,
+    `handle` VARCHAR(64) NOT NULL,
+    `nick`   VARCHAR(64) NOT NULL,
+    PRIMARY KEY (`login`, `account`, `handle`),
+    INDEX `login` (`login`, `account`)
+);

--- a/irc.h
+++ b/irc.h
@@ -91,6 +91,7 @@ typedef struct irc {
 	char *password; /* HACK: Used to save the user's password, but before
 	                   logging in, this may contain a password we should
 	                   send to identify after USER/NICK are received. */
+	char *auth_backend;
 
 	char umode[8];
 

--- a/irc_commands.c
+++ b/irc_commands.c
@@ -43,14 +43,20 @@ static void irc_cmd_pass(irc_t *irc, char **cmd)
 	}
 	/* Handling in pre-logged-in state, first see if this server is
 	   password-protected: */
-	else if (global.conf->auth_pass &&
-	         (strncmp(global.conf->auth_pass, "md5:", 4) == 0 ?
-	          md5_verify_password(cmd[1], global.conf->auth_pass + 4) == 0 :
-	          strcmp(cmd[1], global.conf->auth_pass) == 0)) {
-		irc->status |= USTATUS_AUTHORIZED;
-		irc_check_login(irc);
-	} else if (global.conf->auth_pass) {
-		irc_send_num(irc, 464, ":Incorrect password");
+	else if (global.conf->auth_pass) {
+		int password_ok = 0;
+		if (strncmp(global.conf->auth_pass, "md5:", 4) == 0) {
+			password_ok = password_verify(cmd[1], global.conf->auth_pass + 4) == 0;
+		}
+		else {
+			password_ok = strcmp(cmd[1], global.conf->auth_pass) == 0;
+		}
+		if (password_ok) {
+			irc->status |= USTATUS_AUTHORIZED;
+			irc_check_login(irc);
+		} else {
+			irc_send_num(irc, 464, ":Incorrect password");
+		}
 	} else {
 		/* Remember the password and try to identify after USER/NICK. */
 		irc_setpass(irc, cmd[1]);
@@ -492,15 +498,21 @@ static void irc_cmd_oper_hack(irc_t *irc, char **cmd);
 
 static void irc_cmd_oper(irc_t *irc, char **cmd)
 {
+	int password_ok = 0;
 	/* Very non-standard evil but useful/secure hack, see below. */
 	if (irc->status & OPER_HACK_ANY) {
 		return irc_cmd_oper_hack(irc, cmd);
 	}
 
-	if (global.conf->oper_pass &&
-	    (strncmp(global.conf->oper_pass, "md5:", 4) == 0 ?
-	     md5_verify_password(cmd[2], global.conf->oper_pass + 4) == 0 :
-	     strcmp(cmd[2], global.conf->oper_pass) == 0)) {
+	if (global.conf->oper_pass) {
+		if (strncmp(global.conf->oper_pass, "md5:", 4) == 0) {
+			password_ok = password_verify(cmd[1], global.conf->oper_pass + 4) == 0;
+		}
+		else {
+			password_ok = strcmp(cmd[1], global.conf->oper_pass) == 0;
+		}
+	}
+	if(password_ok) {
 		irc_umode_set(irc, "+o", 1);
 		irc_send_num(irc, 381, ":Password accepted");
 	} else {

--- a/irc_im.c
+++ b/irc_im.c
@@ -119,12 +119,6 @@ static gboolean bee_irc_user_status(bee_t *bee, bee_user_t *bu, bee_user_t *old)
 		iu->flags |= IRC_USER_AWAY;
 	}
 
-	if ((irc->caps & CAP_AWAY_NOTIFY) &&
-	    ((bu->flags & BEE_USER_AWAY) != (old->flags & BEE_USER_AWAY) ||
-	     (bu->flags & BEE_USER_ONLINE) != (old->flags & BEE_USER_ONLINE))) {
-		irc_send_away_notify(iu);
-	}
-
 	if ((bu->flags & BEE_USER_ONLINE) != (old->flags & BEE_USER_ONLINE)) {
 		if (bu->flags & BEE_USER_ONLINE) {
 			if (g_hash_table_lookup(irc->watches, iu->key)) {
@@ -152,6 +146,12 @@ static gboolean bee_irc_user_status(bee_t *bee, bee_user_t *bu, bee_user_t *old)
 	iu->away_reply_timeout = 0;
 
 	bee_irc_channel_update(irc, NULL, iu);
+
+	if ((irc->caps & CAP_AWAY_NOTIFY) &&
+	    ((bu->flags & BEE_USER_AWAY) != (old->flags & BEE_USER_AWAY) ||
+	     (bu->flags & BEE_USER_ONLINE) != (old->flags & BEE_USER_ONLINE))) {
+		irc_send_away_notify(iu);
+	}
 
 	return TRUE;
 }

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -12,7 +12,7 @@ _SRCDIR_ := $(_SRCDIR_)lib/
 endif
 
 # [SH] Program variables
-objects = arc.o base64.o $(EVENT_HANDLER) ftutil.o http_client.o ini.o json.o json_util.o md5.o misc.o oauth.o oauth2.o proxy.o sha1.o $(SSL_CLIENT) url.o xmltree.o ns_parse.o
+objects = arc.o base64.o $(EVENT_HANDLER) ftutil.o http_client.o ini.o json.o json_util.o md5.o misc.o oauth.o oauth2.o proxy.o sha1.o $(SSL_CLIENT) url.o xmltree.o ns_parse.o password.o
 
 LFLAGS += -r
 

--- a/lib/misc.c
+++ b/lib/misc.c
@@ -600,40 +600,6 @@ gboolean ssl_sockerr_again(void *ssl)
 	}
 }
 
-/* Returns values: -1 == Failure (base64-decoded to something unexpected)
-                    0 == Okay
-                    1 == Password doesn't match the hash. */
-int md5_verify_password(char *password, char *hash)
-{
-	md5_byte_t *pass_dec = NULL;
-	md5_byte_t pass_md5[16];
-	md5_state_t md5_state;
-	int ret = -1, i;
-
-	if (base64_decode(hash, &pass_dec) == 21) {
-		md5_init(&md5_state);
-		md5_append(&md5_state, (md5_byte_t *) password, strlen(password));
-		md5_append(&md5_state, (md5_byte_t *) pass_dec + 16, 5);  /* Hmmm, salt! */
-		md5_finish(&md5_state, pass_md5);
-
-		for (i = 0; i < 16; i++) {
-			if (pass_dec[i] != pass_md5[i]) {
-				ret = 1;
-				break;
-			}
-		}
-
-		/* If we reached the end of the loop, it was a match! */
-		if (i == 16) {
-			ret = 0;
-		}
-	}
-
-	g_free(pass_dec);
-
-	return ret;
-}
-
 /* Split commands (root-style, *not* IRC-style). Handles "quoting of"
    white\ space in 'various ways'. Returns a NULL-terminated static
    char** so watch out with nested use! Definitely not thread-safe. */

--- a/lib/misc.h
+++ b/lib/misc.h
@@ -144,7 +144,6 @@ G_MODULE_EXPORT void srv_free(struct ns_srv_reply **srv);
 
 G_MODULE_EXPORT char *word_wrap(const char *msg, int line_len);
 G_MODULE_EXPORT gboolean ssl_sockerr_again(void *ssl);
-G_MODULE_EXPORT int md5_verify_password(char *password, char *hash);
 G_MODULE_EXPORT char **split_command_parts(char *command, int limit);
 G_MODULE_EXPORT char *get_rfc822_header(const char *text, const char *header, int len);
 G_MODULE_EXPORT int truncate_utf8(char *string, int maxlen);

--- a/lib/password.c
+++ b/lib/password.c
@@ -1,0 +1,89 @@
+#define BITLBEE_CORE
+#include "bitlbee.h"
+#include "base64.h"
+#include "arc.h"
+#include "md5.h"
+
+size_t password_hash(const char *password, char **hash)
+{
+	md5_byte_t pass_md5[21];
+	md5_state_t md5_state;
+
+	/* Generate a salted md5sum of the password. Use 5 bytes for the salt
+	   (to prevent dictionary lookups of passwords) to end up with a 21-
+	   byte password hash, more convenient for base64 encoding. */
+	random_bytes(pass_md5 + 16, 5);
+	md5_init(&md5_state);
+	md5_append(&md5_state, (md5_byte_t *) password, strlen(password));
+	md5_append(&md5_state, pass_md5 + 16, 5);   /* Add the salt. */
+	md5_finish(&md5_state, pass_md5);
+
+	/* Save the hash in base64-encoded form. */
+	*hash = base64_encode(pass_md5, 21);
+	return strlen(*hash);
+}
+
+/* Returns values: -1 == Failure (base64-decoded to something unexpected)
+                    0 == Okay
+                    1 == Password doesn't match the hash. */
+int password_verify(const char *password, const char *hash)
+{
+	md5_byte_t *pass_dec = NULL;
+	md5_byte_t pass_md5[16];
+	md5_state_t md5_state;
+	int ret = -1, i;
+
+	if (base64_decode(hash, &pass_dec) == 21) {
+		md5_init(&md5_state);
+		md5_append(&md5_state, (md5_byte_t *) password, strlen(password));
+		md5_append(&md5_state, (md5_byte_t *) pass_dec + 16, 5);  /* Hmmm, salt! */
+		md5_finish(&md5_state, pass_md5);
+
+		for (i = 0; i < 16; i++) {
+			if (pass_dec[i] != pass_md5[i]) {
+				ret = 1;
+				break;
+			}
+		}
+
+		/* If we reached the end of the loop, it was a match! */
+		if (i == 16) {
+			ret = 0;
+		}
+	}
+
+	g_free(pass_dec);
+
+	return ret;
+}
+
+size_t password_encode(const char *password, char **encoded)
+{
+	*encoded = base64_encode((unsigned char *)password, strlen(password));
+	return *encoded ? -1 : strlen(*encoded);
+}
+
+size_t password_decode(const char *encoded, char **password)
+{
+	return base64_decode(encoded, (unsigned char **)password);
+}
+
+size_t password_encrypt(const char *password, const char *encryption_key, char **crypt)
+{
+	unsigned char *encrypted;
+	size_t pass_len = arc_encode((char *)password, strlen(password), &encrypted, (char *)encryption_key, 12);
+	*crypt = base64_encode(encrypted, pass_len);
+	g_free(encrypted);
+	return strlen(*crypt);
+}
+
+size_t password_decrypt(const char *encrypted, const char *encryption_key, char **password)
+{
+	unsigned char *decoded;
+	size_t pass_len = base64_decode(encrypted, &decoded);
+	if (pass_len) {
+		pass_len = arc_decode(decoded, pass_len, password, encryption_key);
+		g_free(decoded);
+	}
+	return pass_len;
+}

--- a/lib/password.h
+++ b/lib/password.h
@@ -1,0 +1,11 @@
+#ifndef _PASSWORD_H
+#define _PASSWORD_H
+
+size_t password_hash(const char *password, char **hash);
+int password_verify(const char *password, const char *hash);
+size_t password_encode(const char *password, char **encoded);
+size_t password_decode(const char *encoded, char **password);
+size_t password_encrypt(const char *password, const char *encryption_key, char **crypt);
+size_t password_decrypt(const char *encrypted, const char *encryption_key, char **password);
+
+#endif

--- a/protocols/account.c
+++ b/protocols/account.c
@@ -66,13 +66,13 @@ account_t *account_add(bee_t *bee, struct prpl *prpl, char *user, char *pass)
 	s->flags |= SET_NOSAVE; /* Just for bw compatibility! */
 
 	s = set_add(&a->set, "password", NULL, set_eval_account, a);
-	s->flags |= SET_NOSAVE | SET_NULL_OK | SET_PASSWORD;
+	s->flags |= SET_NOSAVE | SET_NULL_OK | SET_PASSWORD | ACC_SET_LOCKABLE;
 
 	s = set_add(&a->set, "tag", NULL, set_eval_account, a);
 	s->flags |= SET_NOSAVE;
 
 	s = set_add(&a->set, "username", NULL, set_eval_account, a);
-	s->flags |= SET_NOSAVE | ACC_SET_OFFLINE_ONLY;
+	s->flags |= SET_NOSAVE | ACC_SET_OFFLINE_ONLY | ACC_SET_LOCKABLE;
 	set_setstr(&a->set, "username", user);
 
 	/* Hardcode some more clever tag guesses. */

--- a/protocols/account.h
+++ b/protocols/account.h
@@ -62,6 +62,7 @@ int protocol_account_islocal(const char* protocol);
 typedef enum {
 	ACC_SET_OFFLINE_ONLY = 0x02,    /* Allow changes only if the acct is offline. */
 	ACC_SET_ONLINE_ONLY = 0x04,     /* Allow changes only if the acct is online. */
+	ACC_SET_LOCKABLE = 0x08         /* Setting cannot be changed if the account is locked down */
 } account_set_flag_t;
 
 typedef enum {
@@ -69,6 +70,7 @@ typedef enum {
 	ACC_FLAG_STATUS_MESSAGE = 0x02, /* Supports status messages (without being away). */
 	ACC_FLAG_HANDLE_DOMAINS = 0x04, /* Contact handles need a domain portion. */
 	ACC_FLAG_LOCAL = 0x08,          /* Contact list is local. */
+	ACC_FLAG_LOCKED = 0x10,         /* Account is locked (cannot be deleted, certain settings can't changed) */
 } account_flag_t;
 
 #endif

--- a/protocols/jabber/jabber.c
+++ b/protocols/jabber/jabber.c
@@ -64,11 +64,12 @@ static void jabber_init(account_t *acc)
 
 	g_snprintf(str, sizeof(str), "%d", jabber_port_list[0]);
 	s = set_add(&acc->set, "port", str, set_eval_int, acc);
-	s->flags |= ACC_SET_OFFLINE_ONLY;
+	s->flags |= ACC_SET_OFFLINE_ONLY | ACC_SET_LOCKABLE;
 
 	s = set_add(&acc->set, "priority", "0", set_eval_priority, acc);
 
 	s = set_add(&acc->set, "proxy", "<local>;<auto>", NULL, acc);
+	s->flags |= ACC_SET_LOCKABLE;
 
 	s = set_add(&acc->set, "resource", "BitlBee", NULL, acc);
 	s->flags |= ACC_SET_OFFLINE_ONLY;
@@ -79,7 +80,7 @@ static void jabber_init(account_t *acc)
 	s->flags |= ACC_SET_OFFLINE_ONLY | SET_HIDDEN_DEFAULT;
 
 	s = set_add(&acc->set, "server", NULL, set_eval_account, acc);
-	s->flags |= SET_NOSAVE | ACC_SET_OFFLINE_ONLY | SET_NULL_OK;
+	s->flags |= SET_NOSAVE | ACC_SET_OFFLINE_ONLY | SET_NULL_OK | ACC_SET_LOCKABLE;
 
 	if (strcmp(acc->prpl->name, "hipchat") == 0) {
 		set_setstr(&acc->set, "server", "chat.hipchat.com");

--- a/protocols/msn/msn.c
+++ b/protocols/msn/msn.c
@@ -40,10 +40,10 @@ static void msn_init(account_t *acc)
 	s->flags |= SET_NOSAVE | ACC_SET_ONLINE_ONLY;
 
 	s = set_add(&acc->set, "server", NULL, set_eval_account, acc);
-	s->flags |= SET_NOSAVE | ACC_SET_OFFLINE_ONLY;
+	s->flags |= SET_NOSAVE | ACC_SET_OFFLINE_ONLY | ACC_SET_LOCKABLE;
 
 	s = set_add(&acc->set, "port", MSN_NS_PORT, set_eval_int, acc);
-	s->flags |= ACC_SET_OFFLINE_ONLY;
+	s->flags |= ACC_SET_OFFLINE_ONLY | ACC_SET_LOCKABLE;
 
 	s = set_add(&acc->set, "mail_notifications", "false", set_eval_bool, acc);
 	s->flags |= ACC_SET_OFFLINE_ONLY;

--- a/protocols/oscar/oscar.c
+++ b/protocols/oscar/oscar.c
@@ -390,7 +390,7 @@ static void oscar_init(account_t *acc)
 	s = set_add(&acc->set, "server",
 	            icq ? AIM_DEFAULT_LOGIN_SERVER_ICQ
 		    : AIM_DEFAULT_LOGIN_SERVER_AIM, set_eval_account, acc);
-	s->flags |= SET_NOSAVE | ACC_SET_OFFLINE_ONLY;
+	s->flags |= SET_NOSAVE | ACC_SET_OFFLINE_ONLY | ACC_SET_LOCKABLE;
 
 	if (icq) {
 		s = set_add(&acc->set, "web_aware", "false", set_eval_bool, acc);

--- a/protocols/skype/skype.c
+++ b/protocols/skype/skype.c
@@ -1656,10 +1656,10 @@ static void skype_init(account_t *acc)
 
 	s = set_add(&acc->set, "server", SKYPE_DEFAULT_SERVER, set_eval_account,
 	            acc);
-	s->flags |= ACC_SET_OFFLINE_ONLY;
+	s->flags |= ACC_SET_OFFLINE_ONLY | ACC_SET_LOCKABLE;
 
 	s = set_add(&acc->set, "port", SKYPE_DEFAULT_PORT, set_eval_int, acc);
-	s->flags |= ACC_SET_OFFLINE_ONLY;
+	s->flags |= ACC_SET_OFFLINE_ONLY | ACC_SET_LOCKABLE;
 
 	s = set_add(&acc->set, "display_name", NULL, skype_set_display_name,
 	            acc);

--- a/protocols/twitter/twitter.c
+++ b/protocols/twitter/twitter.c
@@ -473,11 +473,6 @@ int twitter_url_len_diff(gchar *msg, unsigned int target_len)
 		url = g_match_info_fetch(match_info, 2);
 		url_len_diff += target_len - g_utf8_strlen(url, -1);
 
-		/* Add another character for https://t.co/... URLs */
-		if ((s = g_match_info_fetch(match_info, 3))) {
-			url_len_diff += 1;
-			g_free(s);
-		}
 		g_free(url);
 		g_match_info_next(match_info, NULL);
 	}
@@ -540,7 +535,7 @@ static void twitter_init(account_t * acc)
 
 	if (strcmp(acc->prpl->name, "twitter") == 0) {
 		def_url = TWITTER_API_URL;
-		def_tul = "22";
+		def_tul = "23";
 		def_mentions = "true";
 	} else {                /* if( strcmp( acc->prpl->name, "identica" ) == 0 ) */
 		def_url = IDENTICA_API_URL;

--- a/set.h
+++ b/set.h
@@ -48,6 +48,7 @@ typedef enum {
 	SET_HIDDEN = 0x0200,   /* Don't show up in setting lists. Mostly for internal storage. */
 	SET_PASSWORD = 0x0400, /* Value shows up in settings list as "********". */
 	SET_HIDDEN_DEFAULT = 0x0800, /* Hide unless changed from default. */
+	SET_LOCKED = 0x1000    /* Setting is locked, don'w allow changing it */
 } set_flags_t;
 
 typedef struct set {

--- a/storage.c
+++ b/storage.c
@@ -30,6 +30,9 @@
 
 extern storage_t storage_text;
 extern storage_t storage_xml;
+#ifdef WITH_MYSQL
+extern storage_t storage_mysql;
+#endif
 
 static GList *storage_backends = NULL;
 
@@ -68,6 +71,9 @@ GList *storage_init(const char *primary, char **migrate)
 	storage_t *storage;
 
 	register_storage_backend(&storage_xml);
+#ifdef WITH_MYSQL
+	register_storage_backend(&storage_mysql);
+#endif
 
 	storage = storage_init_single(primary);
 	if (storage == NULL || storage->save == NULL) {

--- a/storage.c
+++ b/storage.c
@@ -70,7 +70,7 @@ GList *storage_init(const char *primary, char **migrate)
 	register_storage_backend(&storage_xml);
 
 	storage = storage_init_single(primary);
-	if (storage == NULL && storage->save == NULL) {
+	if (storage == NULL || storage->save == NULL) {
 		return NULL;
 	}
 

--- a/storage.c
+++ b/storage.c
@@ -103,6 +103,10 @@ storage_status_t storage_check_pass(const char *nick, const char *password)
 		}
 	}
 
+	/* If we have configured an authentication backend, try it */
+	if (global.conf->auth_backend)
+		return auth_check_pass(global.conf->auth_backend, nick, password);
+
 	return STORAGE_NO_SUCH_USER;
 }
 
@@ -134,6 +138,16 @@ storage_status_t storage_load(irc_t * irc, const char *password)
 		if (status != STORAGE_NO_SUCH_USER) {
 			return status;
 		}
+	}
+
+	/* If we have configured an authentication backend, try it */
+	if (global.conf->auth_backend) {
+		storage_status_t status = auth_check_pass(global.conf->auth_backend, irc->user->nick, password);
+		if (status == STORAGE_OK) {
+			g_free(irc->auth_backend);
+			irc->auth_backend = g_strdup(global.conf->auth_backend);
+		}
+		return status;
 	}
 
 	return STORAGE_NO_SUCH_USER;

--- a/storage_mysql.c
+++ b/storage_mysql.c
@@ -1,0 +1,462 @@
+#define BILBEE_CORE
+#include "bitlbee.h"
+#include <mysql.h>
+#include <stdarg.h>
+
+/* MySQL config goes in /etc/bitlbee/my.cnf */
+static char *b_mysql_config = ETCDIR "/my.cnf";
+
+static MYSQL* b_mysql_connection(void)
+{
+	MYSQL *con = mysql_init(NULL);
+	if (!con)
+		return NULL;
+	if (mysql_options(con, MYSQL_READ_DEFAULT_FILE, b_mysql_config) != 0) {
+		log_message(LOGLVL_WARNING, "Setting mysql option failed: %s", mysql_error(con));
+		mysql_close(con);
+		return NULL;
+	}
+	if (!mysql_real_connect(con, NULL, NULL, NULL, NULL, 0, NULL, 0)) {
+		log_message(LOGLVL_WARNING, "Database connection failed: %s", mysql_error(con));
+		mysql_close(con);
+		return NULL;
+	}
+	return con;
+}
+
+static void b_mysql_init(void)
+{
+	MYSQL *con = b_mysql_connection();
+	if (!con)
+		log_message(LOGLVL_WARNING, "Unable to access database, configuration won't be saved.");
+	else
+		mysql_close(con);
+}
+
+/* Possibly the worst sprintf implementation possible. What we actually need is
+ * a sprintf wrapper that lets you process all the arguments before passing
+ * them on to the actual printf. Since there's no way to do that, we now have a
+ * very limited vasprintf that only supports the %s specifier (and probably
+ * causes horrible crashes if you use other specifiers. Fortunately, this is
+ * enough. 
+ *
+ * We pass the each of the format's arguments through mysql_real_escape_string.
+ * All arguments processed this way are either table names or WHERE parameters,
+ * so this is safe. We then combine the arguments with the format string by
+ * splitting the format string, splicing in the arguments and joining the
+ * result.
+ *
+ * If only there were an sprintf that accepted an array of parameters :(
+ */
+static char *b_mysql_format(MYSQL *con, const char *query, va_list args)
+{
+	char **items, **combined, *raw, *escaped, *stmt;
+	int i, len;
+
+	items = g_strsplit(query, "%s", -1);
+	len = g_strv_length(items);
+	combined = g_new0(char *, len * 2);
+
+	for(i=0; i<len-1; i++) {
+		combined[i*2] = items[i];
+		raw = va_arg(args, char *);
+		escaped = g_malloc(strlen(raw)*2+1);
+		mysql_real_escape_string(con, escaped, raw, strlen(raw));
+		combined[i*2+1] = escaped;
+	}
+	combined[(len-1)*2] = items[len-1];
+
+	stmt = g_strjoinv(NULL, combined); 
+	g_strfreev(combined);
+	g_free(items);
+
+	return stmt;
+}
+
+static int b_mysql_query(MYSQL *con, const char *query, ...) __attribute__((format (printf, 2,3)));
+static int b_mysql_query(MYSQL *con, const char *query, ...)
+{
+	va_list args;
+	char *stmt;
+	int ret;
+
+	va_start(args, query);
+	stmt = b_mysql_format(con, query, args);
+	va_end(args);
+
+	ret = mysql_real_query(con, stmt, strlen(stmt));
+	if (ret || *mysql_error(con))
+		log_message(LOGLVL_WARNING, "MySQL query \"%s\" failed during query (%d): %s", stmt, ret, mysql_error(con));
+	g_free(stmt);
+	return ret;
+}
+
+static MYSQL_RES *b_mysql_select(MYSQL *con, const char *query, ...) __attribute__((format (printf, 2,3)));
+static MYSQL_RES *b_mysql_select(MYSQL *con, const char *query, ...) {
+	MYSQL_RES *res;
+	va_list args;
+	char *stmt;
+	int ret;
+
+	va_start(args, query);
+	stmt = b_mysql_format(con, query, args);
+	va_end(args);
+
+	ret = mysql_real_query(con, stmt, strlen(stmt));
+	if (ret || *mysql_error(con)) {
+		log_message(LOGLVL_WARNING, "MySQL query \"%s\" failed during query (%d): %s", stmt, ret, mysql_error(con));
+		g_free(stmt);
+		return NULL;
+	}
+
+	res = mysql_store_result(con);
+	if (!res) {
+		log_message(LOGLVL_WARNING, "MySQL query \"%s\" failed during store (%d): %s", stmt, ret, mysql_error(con));
+		g_free(stmt);
+		return NULL;
+	}
+
+	g_free(stmt);
+	return res;
+}
+
+static storage_status_t b_mysql_check_pass_real(irc_t *irc, MYSQL *con, const char *nick, const char *password) {
+	MYSQL_ROW row;
+	MYSQL_RES *res;
+	storage_status_t ret;
+
+	if (!(res = b_mysql_select(con, "SELECT `password`, `auth_backend` FROM `users` WHERE `login`='%s'", nick))) {
+		return STORAGE_OTHER_ERROR;
+	}
+
+	if (mysql_num_rows(res) != 1) {
+		mysql_free_result(res);
+		return STORAGE_NO_SUCH_USER;
+	}
+
+	row = mysql_fetch_row(res);
+	if (row[1] && *row[1]) {
+		ret = auth_check_pass(row[1], nick, password);
+		if ((ret == STORAGE_OK) && irc)
+			irc->auth_backend = g_strdup(row[1]);
+	} else if ((ret = password_verify(password, row[0]))) {
+		ret = (ret == -1) ? STORAGE_OTHER_ERROR : STORAGE_INVALID_PASSWORD;
+	} else {
+		ret = STORAGE_OK;
+	}
+	mysql_free_result(res);
+	return ret;
+}
+
+static storage_status_t b_mysql_check_pass(const char *nickname, const char *password) {
+	MYSQL *con = b_mysql_connection();
+	storage_status_t ret;
+	if (!con) {
+		log_message(LOGLVL_WARNING, "Unable to access database, configuration for %s not saved.", nickname);
+		return STORAGE_OTHER_ERROR;
+	}
+	ret = b_mysql_check_pass_real(NULL, con, nickname, password);
+	mysql_close(con);
+	return ret;
+}
+
+static storage_status_t b_mysql_load_settings(irc_t *irc, MYSQL *con) {
+	MYSQL_ROW row;
+	MYSQL_RES *res;
+	struct set *setting;
+
+	if (!(res = b_mysql_select(con, "SELECT setting, value, locked FROM settings WHERE `login`='%s'", irc->user->nick)))
+		return STORAGE_OTHER_ERROR;
+
+	while ((row = mysql_fetch_row(res))) {
+		set_setstr(&irc->b->set, row[0], row[1]);
+		if (row[2][0] == '1') {
+			setting = set_find(&irc->b->set, row[0]);
+			setting->flags |= SET_LOCKED;
+		}
+	}
+	mysql_free_result(res);
+	return STORAGE_OK;
+}
+
+static storage_status_t b_mysql_load_buddies(irc_t *irc, MYSQL *con, account_t *acc) {
+	MYSQL_RES *res;
+	MYSQL_ROW row;
+
+	if (!(res = b_mysql_select(con, "SELECT handle, nick FROM buddies WHERE `login`='%s' AND `account`='%s'", irc->user->nick, acc->user)))
+		return STORAGE_OTHER_ERROR;
+
+	while ((row = mysql_fetch_row(res)))
+		nick_set_raw(acc, row[0], row[1]);
+	mysql_free_result(res);
+	return STORAGE_OK;
+}
+
+static storage_status_t b_mysql_load_account_settings(irc_t *irc, MYSQL *con, account_t *acc) {
+	MYSQL_ROW row;
+	MYSQL_RES *res;
+	set_t *setting;
+
+	if (!(res = b_mysql_select(con, "SELECT setting, value, locked FROM account_settings WHERE `login`='%s' AND `account`='%s'", irc->user->nick, acc->user)))
+		return STORAGE_OTHER_ERROR;
+
+	while ((row = mysql_fetch_row(res))) {
+		setting = set_find(&acc->set, row[0]);
+		if (setting && setting->flags & ACC_SET_ONLINE_ONLY)
+			continue;
+		set_setstr(&acc->set, row[0], row[1]);
+		if (row[2][0] == '1')
+			setting->flags |= SET_LOCKED;
+	}
+	mysql_free_result(res);
+
+	return b_mysql_load_buddies(irc, con, acc);
+}
+
+static storage_status_t b_mysql_load_accounts(irc_t *irc, MYSQL *con, const char *irc_pass) {
+	MYSQL_ROW row;
+	MYSQL_RES *res;
+	account_t *acc;
+	struct prpl *prpl;
+	storage_status_t ret = STORAGE_OK;
+	char *password;
+	int pass_len;
+
+	if (!(res = b_mysql_select(con, "SELECT account, protocol, password, tag, server, auto_connect, locked FROM accounts WHERE `login`='%s'", irc->user->nick)))
+		return STORAGE_OTHER_ERROR;
+
+	while ((row = mysql_fetch_row(res))) {
+		prpl = find_protocol(row[1]);
+		if (irc->auth_backend)
+			pass_len = password_decode(row[2], &password);
+		else
+			pass_len = password_decrypt(row[2], irc_pass, &password);
+		if (pass_len < 0) {
+			g_free(password);
+			mysql_free_result(res);
+			return STORAGE_OTHER_ERROR;
+		}
+		acc = account_add(irc->b, prpl, row[0], password);
+		g_free(password);
+
+		set_setstr(&acc->set, "tag", row[3]);
+		set_setstr(&acc->set, "server", row[4]);
+		set_setstr(&acc->set, "auto_connect", row[5][0] == '0' ? "true" : "false");
+		if (row[6][0] == '1')
+			acc->flags |= ACC_FLAG_LOCKED;
+
+		ret = b_mysql_load_account_settings(irc, con, acc);
+		if (ret != STORAGE_OK) {
+			mysql_free_result(res);
+			return ret;
+		}
+	}
+
+	mysql_free_result(res);
+	return ret;
+}
+
+
+static storage_status_t b_mysql_load_channels(irc_t *irc, MYSQL *con) {
+	MYSQL_ROW row;
+	MYSQL_RES *res;
+	irc_channel_t *ic;
+	set_t *setting;
+
+	if (!(res = b_mysql_select(con, "SELECT channel, setting, value, locked FROM channel_settings WHERE `login`='%s'", irc->user->nick)))
+		return STORAGE_OTHER_ERROR;
+
+	while ((row = mysql_fetch_row(res))) {
+		ic = irc_channel_by_name(irc, row[0]);
+		if (!ic)
+			ic = irc_channel_new(irc, row[0]);
+		set_setstr(&ic->set, row[1], row[2]);
+		if (row[3][0] == '1') {
+			setting = set_find(&ic->set, row[1]);
+			setting->flags |= SET_LOCKED;
+		}
+	}
+	mysql_free_result(res);
+	return STORAGE_OK;
+}
+
+static storage_status_t b_mysql_load(irc_t *irc, const char *password) {
+	MYSQL *con;
+	storage_status_t ret;
+
+	con = b_mysql_connection();
+	if (!con) {
+		log_message(LOGLVL_WARNING, "Unable to access database, configuration for %s not saved.", irc->user->nick);
+		return STORAGE_OTHER_ERROR;
+	}
+
+	ret = b_mysql_check_pass_real(irc, con, irc->user->nick, password);
+	if (!ret) ret = b_mysql_load_settings(irc, con);
+	if (!ret) ret = b_mysql_load_accounts(irc, con, password);
+	if (!ret) ret = b_mysql_load_channels(irc, con);
+	mysql_close(con);
+	return ret;
+}
+
+#define locked(setting) (((setting)->flags & SET_LOCKED) ? "1" : "0")
+static storage_status_t b_mysql_save_settings(irc_t *irc, MYSQL *con) {
+	set_t *set;
+	char *pass_buf = "";
+	if(!irc->auth_backend)
+		password_hash(irc->password, &pass_buf);
+	if (b_mysql_query(con, "INSERT INTO `users` SET `login`='%s', `password`='%s', `auth_backend`='%s'", 
+	                        irc->user->nick, pass_buf, irc->auth_backend ? irc->auth_backend : ""))
+		return STORAGE_OTHER_ERROR;
+	for(set = irc->b->set; set; set=set->next) {
+		if (!set->value || (set->flags & SET_NOSAVE))
+			continue;
+		if (b_mysql_query(con, "INSERT INTO `settings` SET `login`='%s', `setting`='%s', `value`='%s', `locked`=%s", 
+					irc->user->nick, set->key, set->value, locked(set)))
+			return STORAGE_OTHER_ERROR;
+	}
+	return STORAGE_OK;
+}
+
+static storage_status_t b_mysql_save_accounts(irc_t *irc, MYSQL *con) {
+	account_t *acc;
+	int ret;
+	set_t *set;
+	GHashTableIter iter;
+	char *handle, *nick;
+	char *password;
+
+	for(acc=irc->b->accounts; acc; acc=acc->next) {
+		if(irc->auth_backend) {
+			/* If we don't "own" the password, it may change without us
+			 * knowing, so we cannot encrypt the data, as we then may not be
+			 * able to decrypt it */
+			password_encode(acc->pass, &password);
+		} else {
+			password_encrypt(acc->pass, irc->password, &password);
+		}
+		ret = b_mysql_query(con, 
+		      "INSERT INTO `accounts` SET `login`='%s', `account`='%s', `protocol`='%s', "
+		      "`password`='%s', `tag`='%s', `server`='%s', `auto_connect`=%s, locked=%s",
+		      irc->user->nick, acc->user, acc->prpl->name, password, acc->tag, acc->server ? acc->server : "",
+		      acc->auto_connect ? "1": "0", (acc->flags & ACC_FLAG_LOCKED) ? "1" : "0");
+		if (ret)
+			return STORAGE_OTHER_ERROR;
+
+		for(set = acc->set; set; set=set->next) {
+			if (!set->value || (set->flags & SET_NOSAVE))
+				continue;
+			if (b_mysql_query(con,
+			    "INSERT INTO `account_settings` SET `login`='%s', `account`='%s', `setting`='%s', `value`='%s', `locked`=%s",
+			    irc->user->nick, acc->user, set->key, set->value, locked(set)))
+				return STORAGE_OTHER_ERROR;
+		}
+
+		g_hash_table_iter_init(&iter, acc->nicks);
+		while (g_hash_table_iter_next(&iter, (void**)&handle, (void**)&nick)) {
+			if (b_mysql_query(con, "INSERT INTO `buddies` SET `login`='%s', `account`='%s', `handle`='%s', `nick`='%s'",
+						irc->user->nick, acc->user, handle, nick))
+				return STORAGE_OTHER_ERROR;
+		}
+	}
+	return STORAGE_OK;
+}
+
+static storage_status_t b_mysql_save_channels(irc_t *irc, MYSQL *con) {
+	GSList *l;
+	irc_channel_t *ic;
+	set_t *set;
+
+	for (l=irc->channels; l; l=l->next) {
+		ic = l->data;
+
+		if (ic->flags & IRC_CHANNEL_TEMP)
+			continue;
+
+		for(set = ic->set; set; set=set->next) {
+			if (!set->value || (set->flags & SET_NOSAVE))
+				continue;
+			if (b_mysql_query(con,
+			    "INSERT INTO `channel_settings` SET `login`='%s', `channel`='%s', `setting`='%s', `value`='%s', `locked`=%s",
+			    irc->user->nick, ic->name, set->key, set->value, locked(set)))
+				return STORAGE_OTHER_ERROR;
+		}
+	}
+	return STORAGE_OK;
+}
+
+static storage_status_t b_mysql_remove_real(MYSQL *con, const char *nick) {
+	char *tables[7] = {"users", "accounts", "settings", "account_settings", "channel_settings", "buddies", NULL};
+	int i;
+
+	for(i=0; tables[i]; i++) {
+		if (b_mysql_query(con, "DELETE FROM `%s` WHERE `login`='%s'", tables[i], nick))
+			return STORAGE_OTHER_ERROR;
+	}
+
+	return STORAGE_OK;
+}
+
+static storage_status_t b_mysql_remove(const char *nick, const char *password) {
+	MYSQL *con;
+	storage_status_t ret;
+
+	con = b_mysql_connection();
+	if (!con) {
+		log_message(LOGLVL_WARNING, "Unable to access database, configuration for %s not removed.", nick);
+		return STORAGE_OTHER_ERROR;
+	}
+	ret = b_mysql_check_pass_real(NULL, con, nick, password);
+	if (!ret) ret = b_mysql_remove_real(con, nick);
+
+	mysql_close(con);
+	return ret;
+}
+
+static storage_status_t b_mysql_save(irc_t *irc, int overwrite) {
+	MYSQL *con = b_mysql_connection();
+	MYSQL_RES *res;
+	int ret;
+
+	if (!con) {
+		log_message(LOGLVL_WARNING, "Unable to access database, configuration for %s not saved.", irc->user->nick);
+		return STORAGE_OTHER_ERROR;
+	}
+
+	if (!overwrite) {
+		if (!(res = b_mysql_select(con, "SELECT 1 FROM `users` WHERE `login`='%s'", irc->user->nick))) {
+			mysql_close(con);
+			return STORAGE_OTHER_ERROR;
+		}
+		ret = mysql_num_rows(res);
+		mysql_free_result(res);
+		if (ret) {
+			mysql_close(con);
+			return STORAGE_ALREADY_EXISTS;
+		}
+	}
+
+	if (b_mysql_query(con, "START TRANSACTION"))
+		return STORAGE_OTHER_ERROR;
+
+	ret = b_mysql_remove_real(con, irc->user->nick);
+	if (!ret) ret = b_mysql_save_settings(irc, con);
+	if (!ret) ret = b_mysql_save_accounts(irc, con);
+	if (!ret) ret = b_mysql_save_channels(irc, con);
+
+	if (ret != STORAGE_OK)
+		b_mysql_query(con, "ROLLBACK");
+	else if (b_mysql_query(con, "COMMIT"))
+		ret = STORAGE_OTHER_ERROR;
+
+	mysql_close(con);
+	return ret;
+}
+
+storage_t storage_mysql = {
+	.name = "mysql",
+	.init = b_mysql_init,
+	.check_pass = b_mysql_check_pass,
+	.remove = b_mysql_remove,
+	.load = b_mysql_load,
+	.save = b_mysql_save
+};

--- a/storage_xml.c
+++ b/storage_xml.c
@@ -25,9 +25,6 @@
 
 #define BITLBEE_CORE
 #include "bitlbee.h"
-#include "base64.h"
-#include "arc.h"
-#include "md5.h"
 #include "xmltree.h"
 
 #include <glib/gstdio.h>
@@ -86,15 +83,14 @@ static xt_status handle_account(struct xt_node *node, gpointer data)
 {
 	struct xml_parsedata *xd = data;
 	char *protocol, *handle, *server, *password = NULL, *autoconnect, *tag;
-	char *pass_b64 = NULL;
-	unsigned char *pass_cr = NULL;
+	char *pass_raw = NULL;
 	int pass_len, local = 0;
 	struct prpl *prpl = NULL;
 	account_t *acc;
 	struct xt_node *c;
 
 	handle = xt_find_attr(node, "handle");
-	pass_b64 = xt_find_attr(node, "password");
+	pass_raw = xt_find_attr(node, "password");
 	server = xt_find_attr(node, "server");
 	autoconnect = xt_find_attr(node, "autoconnect");
 	tag = xt_find_attr(node, "tag");
@@ -109,21 +105,18 @@ static xt_status handle_account(struct xt_node *node, gpointer data)
 		local = protocol_account_islocal(protocol);
 	}
 
-	if (!handle || !pass_b64 || !protocol || !prpl) {
+	if (!handle || !pass_raw || !protocol || !prpl) {
 		return XT_ABORT;
 	}
-	pass_len = base64_decode(pass_b64, (unsigned char **) &pass_cr);
-	if (pass_len < 0) {
-		g_free(pass_cr);
-		return XT_ABORT;
+
+	if (xd->irc->auth_backend) {
+		pass_len = password_decode(pass_raw, &password);
 	}
-	if (xd->irc->auth_backend)
-		password = g_strdup((char *)pass_cr);
-	else
-		pass_len = arc_decode(pass_cr, pass_len, &password, xd->given_pass);
+	else {
+		pass_len = password_decrypt(pass_raw, xd->given_pass, &password);
+	}
+
 	if (pass_len < 0) {
-		g_free(pass_cr);
-		g_free(password);
 		return XT_ABORT;
 	}
 
@@ -141,7 +134,6 @@ static xt_status handle_account(struct xt_node *node, gpointer data)
 		acc->flags |= ACC_FLAG_LOCAL;
 	}
 
-	g_free(pass_cr);
 	g_free(password);
 
 	handle_settings(node, &acc->set);
@@ -249,8 +241,8 @@ static storage_status_t xml_load_real(irc_t *irc, const char *my_nick, const cha
 				goto error;
 			g_free(xd->irc->auth_backend);
 			xd->irc->auth_backend = g_strdup(backend);
-		} else if ((st = md5_verify_password(xd->given_pass, pass)) != 0) {
-			ret = STORAGE_INVALID_PASSWORD;
+		} else if ((ret = password_verify(xd->given_pass, pass)) != 0) {
+			ret = (ret == -1) ? STORAGE_OTHER_ERROR : STORAGE_INVALID_PASSWORD;
 			goto error;
 		}
 	}
@@ -290,8 +282,6 @@ struct xt_node *xml_generate(irc_t *irc)
 {
 	char *pass_buf = NULL;
 	account_t *acc;
-	md5_byte_t pass_md5[21];
-	md5_state_t md5_state;
 	GSList *l;
 	struct xt_node *root, *cur;
 
@@ -299,16 +289,7 @@ struct xt_node *xml_generate(irc_t *irc)
 	if (irc->auth_backend) {
 		xt_add_attr(cur, "auth_backend", irc->auth_backend);
 	} else {
-		/* Generate a salted md5sum of the password. Use 5 bytes for the salt
-		   (to prevent dictionary lookups of passwords) to end up with a 21-
-		   byte password hash, more convenient for base64 encoding. */
-		random_bytes(pass_md5 + 16, 5);
-		md5_init(&md5_state);
-		md5_append(&md5_state, (md5_byte_t *) irc->password, strlen(irc->password));
-		md5_append(&md5_state, pass_md5 + 16, 5);   /* Add the salt. */
-		md5_finish(&md5_state, pass_md5);
-		/* Save the hash in base64-encoded form. */
-		pass_buf = base64_encode(pass_md5, 21);
+		password_hash(irc->password, &pass_buf);
 		xt_add_attr(cur, "password", pass_buf);
 		g_free(pass_buf);
 	}
@@ -321,32 +302,28 @@ struct xt_node *xml_generate(irc_t *irc)
 	for (acc = irc->b->accounts; acc; acc = acc->next) {
 		GHashTableIter iter;
 		gpointer key, value;
-		unsigned char *pass_cr;
-		char *pass_b64;
-		int pass_len;
+		char *password;
 
 		if(irc->auth_backend) {
 			/* If we don't "own" the password, it may change without us
 			 * knowing, so we cannot encrypt the data, as we then may not be
 			 * able to decrypt it */
-			pass_b64 = base64_encode((unsigned char *)acc->pass, strlen(acc->pass));
+			password_encode(acc->pass, &password);
 		} else {
-			pass_len = arc_encode(acc->pass, strlen(acc->pass), (unsigned char **) &pass_cr, irc->password, 12);
-			pass_b64 = base64_encode(pass_cr, pass_len);
-			g_free(pass_cr);
+			password_encrypt(acc->pass, irc->password, &password);
 		}
 
 		cur = xt_new_node("account", NULL, NULL);
 		xt_add_attr(cur, "protocol", acc->prpl->name);
 		xt_add_attr(cur, "handle", acc->user);
-		xt_add_attr(cur, "password", pass_b64);
+		xt_add_attr(cur, "password", password);
 		xt_add_attr(cur, "autoconnect", acc->auto_connect ? "true" : "false");
 		xt_add_attr(cur, "tag", acc->tag);
 		if (acc->server && acc->server[0]) {
 			xt_add_attr(cur, "server", acc->server);
 		}
 
-		g_free(pass_b64);
+		g_free(password);
 
 		g_hash_table_iter_init(&iter, acc->nicks);
 		while (g_hash_table_iter_next(&iter, &key, &value)) {

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -14,7 +14,7 @@ clean:
 
 distclean: clean
 
-main_objs = bitlbee.o conf.o dcc.o help.o ipc.o irc.o irc_cap.o irc_channel.o irc_commands.o irc_im.o irc_send.o irc_user.o irc_util.o irc_commands.o log.o nick.o query.o root_commands.o set.o storage.o storage_xml.o auth.o auth_pam.o auth_ldap.o
+main_objs = bitlbee.o conf.o dcc.o help.o ipc.o irc.o irc_cap.o irc_channel.o irc_commands.o irc_im.o irc_send.o irc_user.o irc_util.o irc_commands.o log.o nick.o query.o root_commands.o set.o storage.o storage_xml.o storage_mysql.o auth.o auth_pam.o auth_ldap.o
 
 test_objs = check.o check_util.o check_nick.o check_md5.o check_arc.o check_irc.o check_help.o check_user.o check_set.o check_jabber_sasl.o check_jabber_util.o
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -14,7 +14,7 @@ clean:
 
 distclean: clean
 
-main_objs = bitlbee.o conf.o dcc.o help.o ipc.o irc.o irc_cap.o irc_channel.o irc_commands.o irc_im.o irc_send.o irc_user.o irc_util.o irc_commands.o log.o nick.o query.o root_commands.o set.o storage.o storage_xml.o auth.o auth_pam.o
+main_objs = bitlbee.o conf.o dcc.o help.o ipc.o irc.o irc_cap.o irc_channel.o irc_commands.o irc_im.o irc_send.o irc_user.o irc_util.o irc_commands.o log.o nick.o query.o root_commands.o set.o storage.o storage_xml.o auth.o auth_pam.o auth_ldap.o
 
 test_objs = check.o check_util.o check_nick.o check_md5.o check_arc.o check_irc.o check_help.o check_user.o check_set.o check_jabber_sasl.o check_jabber_util.o
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -14,7 +14,7 @@ clean:
 
 distclean: clean
 
-main_objs = bitlbee.o conf.o dcc.o help.o ipc.o irc.o irc_cap.o irc_channel.o irc_commands.o irc_im.o irc_send.o irc_user.o irc_util.o irc_commands.o log.o nick.o query.o root_commands.o set.o storage.o storage_xml.o
+main_objs = bitlbee.o conf.o dcc.o help.o ipc.o irc.o irc_cap.o irc_channel.o irc_commands.o irc_im.o irc_send.o irc_user.o irc_util.o irc_commands.o log.o nick.o query.o root_commands.o set.o storage.o storage_xml.o auth.o
 
 test_objs = check.o check_util.o check_nick.o check_md5.o check_arc.o check_irc.o check_help.o check_user.o check_set.o check_jabber_sasl.o check_jabber_util.o
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -14,7 +14,7 @@ clean:
 
 distclean: clean
 
-main_objs = bitlbee.o conf.o dcc.o help.o ipc.o irc.o irc_cap.o irc_channel.o irc_commands.o irc_im.o irc_send.o irc_user.o irc_util.o irc_commands.o log.o nick.o query.o root_commands.o set.o storage.o storage_xml.o auth.o
+main_objs = bitlbee.o conf.o dcc.o help.o ipc.o irc.o irc_cap.o irc_channel.o irc_commands.o irc_im.o irc_send.o irc_user.o irc_util.o irc_commands.o log.o nick.o query.o root_commands.o set.o storage.o storage_xml.o auth.o auth_pam.o
 
 test_objs = check.o check_util.o check_nick.o check_md5.o check_arc.o check_irc.o check_help.o check_user.o check_set.o check_jabber_sasl.o check_jabber_util.o
 

--- a/unix.c
+++ b/unix.c
@@ -69,6 +69,9 @@ int main(int argc, char *argv[])
 	}
 
 	log_init();
+	/* Catch early errors */
+	log_link(LOGLVL_ERROR, LOGOUTPUT_CONSOLE);
+	log_link(LOGLVL_WARNING, LOGOUTPUT_CONSOLE);
 
 	global.conf_file = g_strdup(CONF_FILE_DEF);
 	global.conf = conf_load(argc, argv);

--- a/unix.c
+++ b/unix.c
@@ -103,6 +103,12 @@ int main(int argc, char *argv[])
 		return(1);
 	}
 
+	global.auth = auth_init(global.conf->auth_backend);
+	if (global.conf->auth_backend && global.auth == NULL) {
+		log_message(LOGLVL_ERROR, "Unable to load authentication backend '%s'", global.conf->auth_backend);
+		return(1);
+	}
+
 	if (global.conf->runmode == RUNMODE_INETD) {
 		log_link(LOGLVL_ERROR, LOGOUTPUT_IRC);
 		log_link(LOGLVL_WARNING, LOGOUTPUT_IRC);

--- a/unix.c
+++ b/unix.c
@@ -25,13 +25,10 @@
 
 #include "bitlbee.h"
 
-#include "arc.h"
-#include "base64.h"
 #include "commands.h"
 #include "protocols/nogaim.h"
 #include "help.h"
 #include "ipc.h"
-#include "md5.h"
 #include "misc.h"
 #include <signal.h>
 #include <unistd.h>
@@ -206,9 +203,6 @@ int main(int argc, char *argv[])
 
 static int crypt_main(int argc, char *argv[])
 {
-	int pass_len;
-	unsigned char *pass_cr, *pass_cl;
-
 	if (argc < 4 || (strcmp(argv[2], "hash") != 0 &&
 	                 strcmp(argv[2], "unhash") != 0 && argc < 5)) {
 		printf("Supported:\n"
@@ -220,40 +214,25 @@ static int crypt_main(int argc, char *argv[])
 		       argv[0], argv[0], argv[0], argv[0], argv[0]);
 	} else if (strcmp(argv[2], "enc") == 0) {
 		char *encoded;
-
-		pass_len = arc_encode(argv[4], strlen(argv[4]), &pass_cr, argv[3], 12);
-
-		encoded = base64_encode(pass_cr, pass_len);
+		password_encrypt(argv[4], argv[3], &encoded);
 		printf("%s\n", encoded);
 		g_free(encoded);
-		g_free(pass_cr);
 	} else if (strcmp(argv[2], "dec") == 0) {
-		pass_len = base64_decode(argv[4], &pass_cr);
-		arc_decode(pass_cr, pass_len, (char **) &pass_cl, argv[3]);
-		printf("%s\n", pass_cl);
-
-		g_free(pass_cr);
-		g_free(pass_cl);
+		char *decoded;
+		password_decrypt(argv[4], argv[3], &decoded);
+		printf("%s\n", decoded);
+		g_free(decoded);
 	} else if (strcmp(argv[2], "hash") == 0) {
-		md5_byte_t pass_md5[21];
-		md5_state_t md5_state;
-		char *encoded;
-
-		random_bytes(pass_md5 + 16, 5);
-		md5_init(&md5_state);
-		md5_append(&md5_state, (md5_byte_t *) argv[3], strlen(argv[3]));
-		md5_append(&md5_state, pass_md5 + 16, 5);   /* Add the salt. */
-		md5_finish(&md5_state, pass_md5);
-
-		encoded = base64_encode(pass_md5, 21);
-		printf("%s\n", encoded);
-		g_free(encoded);
+		char *hash;
+		password_hash(argv[3], &hash);
+		printf("%s\n", hash);
+		g_free(hash);
 	} else if (strcmp(argv[2], "unhash") == 0) {
 		printf("Hash %s submitted to a massive Beowulf cluster of\n"
 		       "overclocked 486s. Expect your answer next year somewhere around this time. :-)\n", argv[3]);
 	} else if (strcmp(argv[2], "chkhash") == 0) {
 		char *hash = strncmp(argv[3], "md5:", 4) == 0 ? argv[3] + 4 : argv[3];
-		int st = md5_verify_password(argv[4], hash);
+		int st = password_verify(argv[4], hash);
 
 		printf("Hash %s given password.\n", st == 0 ? "matches" : "does not match");
 


### PR DESCRIPTION
As threatened, here is a MySQL storage backend for BitlBee. As it depends on my
locked down accounts, authentication backend and password modernization
branches, it is absolutely not suitable as is for merging, consider this a preview.

It does work though, quite well even :smile:

All but the last three commits are part of other PR's or merges with them,
please ignore those. The third to last one fixes a minor annoyance around early
logging that got in the way of debugging. The second to last fixes a bug in the
handling of non-default storage backends and the last bug is the big commit
with the new backend.

It's completely optional and configure will not even complain if you don't have
the mysql headers installed. But if you do have them installed, it will build
the backend. I could add a --mysql=[01] knob if desired, but autodetecion works
for me.

I've added the schema in doc/ and updated the example config to mention the
AccountStorage setting, but have not added it to the documentation yet.
