### PR TITLE
Twitter mutes

### DIFF
--- a/protocols/twitter/twitter.c
+++ b/protocols/twitter/twitter.c
@@ -957,6 +957,12 @@ static void twitter_handle_command(struct im_connection *ic, char *message)
 	} else if (g_strcasecmp(cmd[0], "unfollow") == 0 && cmd[1]) {
 		twitter_remove_buddy(ic, cmd[1], NULL);
 		goto eof;
+	} else if (g_strcasecmp(cmd[0], "mute") == 0 && cmd[1]) {
+		twitter_mute_create_destroy(ic, cmd[1], 1);
+		goto eof;
+	} else if (g_strcasecmp(cmd[0], "unmute") == 0 && cmd[1]) {
+		twitter_mute_create_destroy(ic, cmd[1], 0);
+		goto eof;
 	} else if ((g_strcasecmp(cmd[0], "report") == 0 ||
 	            g_strcasecmp(cmd[0], "spam") == 0) && cmd[1]) {
 		char *screen_name;

--- a/protocols/twitter/twitter.c
+++ b/protocols/twitter/twitter.c
@@ -344,6 +344,8 @@ void twitter_login_finish(struct im_connection *ic)
 	           !(td->flags & TWITTER_HAVE_FRIENDS)) {
 		imcb_log(ic, "Getting contact list");
 		twitter_get_friends_ids(ic, -1);
+		twitter_get_mutes_ids(ic, -1);
+		twitter_get_noretweets_ids(ic, -1);
 	} else {
 		twitter_main_loop_start(ic);
 	}

--- a/protocols/twitter/twitter.h
+++ b/protocols/twitter/twitter.h
@@ -60,6 +60,8 @@ struct twitter_data {
 	guint64 timeline_id;
 
 	GSList *follow_ids;
+	GSList *mutes_ids;
+	GSList *noretweets_ids;
 	GSList *filters;
 
 	guint64 last_status_id; /* For undo */

--- a/protocols/twitter/twitter_lib.c
+++ b/protocols/twitter/twitter_lib.c
@@ -1652,6 +1652,19 @@ void twitter_friendships_create_destroy(struct im_connection *ic, char *who, int
 	             twitter_http_post, ic, 1, args, 2);
 }
 
+/**
+ * Mute or unmute a user
+ */
+void twitter_mute_create_destroy(struct im_connection *ic, char *who, int create)
+{
+	char *args[2];
+
+	args[0] = "screen_name";
+	args[1] = who;
+	twitter_http(ic, create ? TWITTER_MUTES_CREATE_URL : TWITTER_MUTES_DESTROY_URL,
+		     twitter_http_post, ic, 1, args, 2);
+}
+
 void twitter_status_destroy(struct im_connection *ic, guint64 id)
 {
 	char *url;

--- a/protocols/twitter/twitter_lib.h
+++ b/protocols/twitter/twitter_lib.h
@@ -62,6 +62,8 @@
 /* Social graphs URLs */
 #define TWITTER_FRIENDS_IDS_URL "/friends/ids.json"
 #define TWITTER_FOLLOWERS_IDS_URL "/followers/ids.json"
+#define TWITTER_MUTES_IDS_URL "/mutes/users/ids.json"
+#define TWITTER_NORETWEETS_IDS_URL "/friendships/no_retweets/ids.json"
 
 /* Account URLs */
 #define TWITTER_ACCOUNT_RATE_LIMIT_URL "/account/rate_limit_status.json"
@@ -86,6 +88,8 @@ gboolean twitter_open_stream(struct im_connection *ic);
 gboolean twitter_open_filter_stream(struct im_connection *ic);
 gboolean twitter_get_timeline(struct im_connection *ic, gint64 next_cursor);
 void twitter_get_friends_ids(struct im_connection *ic, gint64 next_cursor);
+void twitter_get_mutes_ids(struct im_connection *ic, gint64 next_cursor);
+void twitter_get_noretweets_ids(struct im_connection *ic, gint64 next_cursor);
 void twitter_get_statuses_friends(struct im_connection *ic, gint64 next_cursor);
 
 void twitter_post_status(struct im_connection *ic, char *msg, guint64 in_reply_to);

--- a/protocols/twitter/twitter_lib.h
+++ b/protocols/twitter/twitter_lib.h
@@ -77,6 +77,10 @@
 #define TWITTER_BLOCKS_CREATE_URL "/blocks/create/"
 #define TWITTER_BLOCKS_DESTROY_URL "/blocks/destroy/"
 
+/* Mute URLs */
+#define TWITTER_MUTES_CREATE_URL "/mutes/users/create.json"
+#define TWITTER_MUTES_DESTROY_URL "/mutes/users/destroy.json"
+
 /* Report spam */
 #define TWITTER_REPORT_SPAM_URL "/users/report_spam.json"
 
@@ -95,6 +99,7 @@ void twitter_get_statuses_friends(struct im_connection *ic, gint64 next_cursor);
 void twitter_post_status(struct im_connection *ic, char *msg, guint64 in_reply_to);
 void twitter_direct_messages_new(struct im_connection *ic, char *who, char *message);
 void twitter_friendships_create_destroy(struct im_connection *ic, char *who, int create);
+void twitter_mute_create_destroy(struct im_connection *ic, char *who, int create);
 void twitter_status_destroy(struct im_connection *ic, guint64 id);
 void twitter_status_retweet(struct im_connection *ic, guint64 id);
 void twitter_report_spam(struct im_connection *ic, char *screen_name);


### PR DESCRIPTION
This branch makes bitlbee honour the user's list of mutes and "hide retweets from this user" settings.

Mutes and no-retweets are fetched from the server upon connection, and stored in two new GSLists in twitter_data. Those lists are scanned before displaying the tweet.