### PR TITLE
Fix use of un-initialized variable

### DIFF
--- a/storage_xml.c
+++ b/storage_xml.c
@@ -120,7 +120,7 @@ static xt_status handle_account(struct xt_node *node, gpointer data)
 		return XT_ABORT;
 	}
 
-	base64_decode(pass_b64, (unsigned char **) &pass_cr);
+	pass_len = base64_decode(pass_b64, (unsigned char **) &pass_cr);
 	if (xd->irc->auth_backend) {
 		password = g_strdup((char *)pass_cr);
 	} else {


### PR DESCRIPTION
On line [127 of storage_xml.c](https://github.com/bitlbee/bitlbee/blob/8e6ecfe23ff985e57675bd00b94860edb62de9ad/storage_xml.c#L127) there is a use of `pass_len` which has not yet been initialized. This made bitlbee return "Unknown error while loading configuration" on login. This PR fixes this by correctly initializing the variable before it's used.