### PR TITLE
Fix segfault when CAP END is received multiple times

### DIFF
--- a/irc_cap.c
+++ b/irc_cap.c
@@ -176,6 +176,9 @@ void irc_cmd_cap(irc_t *irc, char **cmd)
 		irc_send_cap(irc, ack ? "ACK" : "NAK", cmd[2] ? : "");
 
 	} else if (g_strcasecmp(cmd[1], "END") == 0) {
+		if (!(irc->status & USTATUS_CAP_PENDING)) {
+			return;
+		}
 		irc->status &= ~USTATUS_CAP_PENDING;
 
 		if (irc->status & USTATUS_SASL_PLAIN_PENDING) {


### PR DESCRIPTION
If bitlbee receives the command CAP END after the user is registered it will currently segfault. This PR fixes this by ignoring CAP END after the user is registered (which is according to the spec is the correct behavior).