### PR TITLE
Twitter: add "like" as an alias for favourite.

### DIFF
--- a/protocols/twitter/twitter.c
+++ b/protocols/twitter/twitter.c
@@ -950,7 +950,8 @@ static void twitter_handle_command(struct im_connection *ic, char *message)
 		goto eof;
 	} else if ((g_strcasecmp(cmd[0], "favourite") == 0 ||
 	            g_strcasecmp(cmd[0], "favorite") == 0 ||
-	            g_strcasecmp(cmd[0], "fav") == 0) && cmd[1]) {
+	            g_strcasecmp(cmd[0], "fav") == 0 ||
+	            g_strcasecmp(cmd[0], "like") == 0) && cmd[1]) {
 		if ((id = twitter_message_id_from_command_arg(ic, cmd[1], NULL))) {
 			twitter_favourite_tweet(ic, id);
 		} else {


### PR DESCRIPTION
This will allow a user to type "like" in Twitter channels, reflecting recent changes to Twitter itself. Note that the API hasn't changed.