### PR TITLE
Remove the ARCH / CPU defines.

### DIFF
--- a/configure
+++ b/configure
@@ -56,9 +56,6 @@ ldap=0
 
 pie=1
 
-arch=$(uname -s)
-cpu=$(uname -m)
-
 GLIB_MIN_VERSION=2.16
 
 # Cygwin and Darwin don't support PIC/PIE
@@ -199,8 +196,6 @@ INCLUDEDIR=$includedir
 PCDIR=$pcdir
 
 TARGET=$target
-ARCH=$arch
-CPU=$cpu
 
 INSTALL=install -p
 
@@ -247,8 +242,6 @@ cat<<EOF >config.h
 #define PLUGINDIR "$plugindir"
 #define PIDFILE "$pidfile"
 #define IPCSOCKET "$ipcsocket"
-#define ARCH "$arch"
-#define CPU "$cpu"
 EOF
 
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+bitlbee (3.4.2-1) UNRELEASED; urgency=medium
+
+  * Make the build reproducible by not encoding ARCH / CPU defines in
+    the binary.
+
+ -- Jelmer Vernooĳ <jelmer@debian.org>  Sun, 15 May 2016 17:15:13 +0000
+
 bitlbee (3.4.1-1) unstable; urgency=medium
 
   * Fix copyright info (Closes: #764181)

--- a/irc_commands.c
+++ b/irc_commands.c
@@ -766,8 +766,8 @@ static void irc_cmd_list(irc_t *irc, char **cmd)
 
 static void irc_cmd_version(irc_t *irc, char **cmd)
 {
-	irc_send_num(irc, 351, "%s-%s. %s :%s/%s ",
-	             PACKAGE, BITLBEE_VERSION, irc->root->host, ARCH, CPU);
+	irc_send_num(irc, 351, "%s-%s. %s :",
+	             PACKAGE, BITLBEE_VERSION, irc->root->host);
 }
 
 static void irc_cmd_completions(irc_t *irc, char **cmd)

--- a/irc_send.c
+++ b/irc_send.c
@@ -40,8 +40,8 @@ void irc_send_num(irc_t *irc, int code, char *format, ...)
 void irc_send_login(irc_t *irc)
 {
 	irc_send_num(irc,   1, ":Welcome to the %s gateway, %s", PACKAGE, irc->user->nick);
-	irc_send_num(irc,   2, ":Host %s is running %s %s %s/%s.", irc->root->host,
-	             PACKAGE, BITLBEE_VERSION, ARCH, CPU);
+	irc_send_num(irc,   2, ":Host %s is running %s %s.", irc->root->host,
+	             PACKAGE, BITLBEE_VERSION);
 	irc_send_num(irc,   3, ":%s", IRCD_INFO);
 	irc_send_num(irc,   4, "%s %s %s %s", irc->root->host, BITLBEE_VERSION, UMODES UMODES_PRIV, CMODES);
 	irc_send_num(irc,   5, "PREFIX=(ohv)@%%+ CHANTYPES=%s CHANMODES=,,,%s NICKLEN=%d CHANNELLEN=%d "

--- a/irc_user.c
+++ b/irc_user.c
@@ -250,7 +250,7 @@ static gboolean root_ctcp(irc_user_t *iu, char * const *ctcp)
 {
 	if (g_strcasecmp(ctcp[0], "VERSION") == 0) {
 		irc_send_msg_f(iu, "NOTICE", iu->irc->user->nick, "\001%s %s\001",
-		               ctcp[0], PACKAGE " " BITLBEE_VERSION " " ARCH "/" CPU);
+		               ctcp[0], PACKAGE " " BITLBEE_VERSION);
 	} else if (g_strcasecmp(ctcp[0], "PING") == 0) {
 		irc_send_msg_f(iu, "NOTICE", iu->irc->user->nick, "\001%s %s\001",
 		               ctcp[0], ctcp[1] ? : "");

--- a/lib/http_client.c
+++ b/lib/http_client.c
@@ -94,7 +94,7 @@ struct http_request *http_dorequest_url(char *url_string, http_input_function fu
 
 	request = g_strdup_printf("GET %s HTTP/1.0\r\n"
 	                          "Host: %s\r\n"
-	                          "User-Agent: BitlBee " BITLBEE_VERSION " " ARCH "/" CPU "\r\n"
+	                          "User-Agent: BitlBee " BITLBEE_VERSION "\r\n"
 	                          "\r\n", url->file, url->host);
 
 	ret = http_dorequest(url->host, url->port,

--- a/protocols/jabber/iq.c
+++ b/protocols/jabber/iq.c
@@ -66,7 +66,6 @@ xt_status jabber_pkt_iq(struct xt_node *node, gpointer data)
 		if (strcmp(s, XMLNS_VERSION) == 0) {
 			xt_add_child(reply, xt_new_node("name", set_getstr(&ic->acc->set, "user_agent"), NULL));
 			xt_add_child(reply, xt_new_node("version", BITLBEE_VERSION, NULL));
-			xt_add_child(reply, xt_new_node("os", ARCH, NULL));
 		} else if (strcmp(s, XMLNS_TIME_OLD) == 0) {
 			time_t time_ep;
 			char buf[1024];

--- a/protocols/twitter/twitter_http.c
+++ b/protocols/twitter/twitter_http.c
@@ -78,7 +78,7 @@ struct http_request *twitter_http(struct im_connection *ic, char *url_string, ht
 	// Make the request.
 	g_string_printf(request, "%s %s%s%s%s HTTP/1.1\r\n"
 	                "Host: %s\r\n"
-	                "User-Agent: BitlBee " BITLBEE_VERSION " " ARCH "/" CPU "\r\n",
+	                "User-Agent: BitlBee " BITLBEE_VERSION "\r\n",
 	                is_post ? "POST" : "GET",
 	                base_url ? base_url->file : td->url_path,
 	                base_url ? "" : url_string,


### PR DESCRIPTION
These only reflect on what arch/cpu bitlbee was built, not on which
it is running. This makes the Debian package unreproducible.
See e.g. https://tests.reproducible-builds.org/rb-pkg/testing/i386/bitlbee.html