### PR TITLE
Use the correct error message when no authentication schemes are supported

### DIFF
--- a/protocols/jabber/sasl.c
+++ b/protocols/jabber/sasl.c
@@ -89,7 +89,7 @@ xt_status sasl_pkt_mechanisms(struct xt_node *node, gpointer data)
 	}
 
 	if (!want_oauth && !sup_plain && !sup_digest) {
-		if (!sup_gtalk) {
+		if (sup_gtalk) {
 			imcb_error(ic, "This server requires OAuth "
 			           "(supported schemes:%s)", mechs->str);
 		} else {


### PR DESCRIPTION
This will make bitlbee tell the user about the requirement for oauth when the server actually announces support for oauth. If the server does not announce oauth support bitlbee will tell the user it doesn't support any of the schemes provided by the server.

These messages were reversed before.