### PR TITLE
debian: install systemd units and use dh_systemd

### DIFF
--- a/debian/bitlbee-common.postinst
+++ b/debian/bitlbee-common.postinst
@@ -9,8 +9,6 @@ PORT="$RET"
 
 CONFDIR=/var/lib/bitlbee/
 
-update-rc.d bitlbee defaults > /dev/null 2>&1
-
 ## Load default option. Don't want to put this in debconf (yet?)
 BITLBEE_OPTS=-F
 BITLBEE_DISABLED=0
@@ -91,6 +89,4 @@ else
 	chown bitlbee /etc/bitlbee/bitlbee.conf
 fi
 
-if [ -z "$2" ]; then
-	invoke-rc.d bitlbee start
-fi
+#DEBHELPER#

--- a/debian/bitlbee-common.postrm
+++ b/debian/bitlbee-common.postrm
@@ -2,15 +2,10 @@
 
 set -e
 
-[ "$1" = "purge" ] || exit 0
-
-if [ -e /usr/share/debconf/confmodule ]; then
-	. /usr/share/debconf/confmodule;
-	db_purge;
+if [ "$1" = "purge" ]; then
+	rm -f /etc/default/bitlbee
+	deluser --system bitlbee || true
+	rm -rf /var/lib/bitlbee ## deluser doesn't seem to do this for homedirs in /var
 fi
 
-update-rc.d bitlbee remove > /dev/null 2>&1 || true
-rm -f /etc/default/bitlbee
-
-deluser --system bitlbee || true
-rm -rf /var/lib/bitlbee ## deluser doesn't seem to do this for homedirs in /var
+#DEBHELPER#

--- a/debian/bitlbee-common.prerm
+++ b/debian/bitlbee-common.prerm
@@ -10,6 +10,6 @@ if [ "$1" = "upgrade" ]; then
 		rm -f /usr/share/bitlbee/help.upgrading
 		mv /usr/share/bitlbee/help.txt /usr/share/bitlbee/help.upgrading
 	fi
-else
-	invoke-rc.d bitlbee stop
 fi
+
+#DEBHELPER#

--- a/debian/bitlbee.prerm
+++ b/debian/bitlbee.prerm
@@ -5,3 +5,5 @@ set -e
 if [ "$1" != "upgrade" ]; then
 	invoke-rc.d bitlbee stop
 fi
+
+#DEBHELPER#

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Wilmer van der Gaast <wilmer@gaast.net>
 Uploaders: Jelmer Vernooĳ <jelmer@debian.org>
 Standards-Version: 3.9.8
-Build-Depends: libglib2.0-dev (>= 2.4), libevent-dev, libgnutls28-dev | libgnutls-dev | gnutls-dev, po-debconf, libpurple-dev, libotr5-dev, debhelper (>= 6.0.7~)
+Build-Depends: libglib2.0-dev (>= 2.4), libevent-dev, libgnutls28-dev | libgnutls-dev | gnutls-dev, po-debconf, libpurple-dev, libotr5-dev, debhelper (>= 6.0.7~), dh-systemd (>= 1.5) | debhelper (<< 9.20131227)
 Homepage: http://www.bitlbee.org/
 Vcs-Git: https://github.com/bitlbee/bitlbee
 Vcs-Browser: https://github.com/bitlbee/bitlbee

--- a/debian/rules
+++ b/debian/rules
@@ -39,6 +39,8 @@ LDFLAGS:=$(shell dpkg-buildflags --get LDFLAGS)
 
 CONFIGURE_OVERRIDES:=CPPFLAGS="$(CPPFLAGS)" CFLAGS="$(CFLAGS)" LDFLAGS="$(LDFLAGS)"
 
+HAS_DH_SYSTEMD:=$(shell dpkg-query -W -f='$${Status}' dh-systemd 2>/dev/null | grep -c "ok installed")
+
 build: build-stamp
 build-stamp:
 	dh_testdir
@@ -80,6 +82,10 @@ install: build
 	$(MAKE) -C debian/build-native install-plugin-otr DESTDIR=`pwd`/debian/bitlbee-plugin-otr
 	$(MAKE) -C debian/build-native install-plugin-skype DESTDIR=`pwd`/debian/skyped
 
+ifeq ($(HAS_DH_SYSTEMD),1)
+	$(MAKE) -C debian/build-native install-systemd DESTDIR=`pwd`/debian/bitlbee-common
+endif
+
 ifneq ($(BITLBEE_SKYPE),0)
 	mkdir -p debian/bitlbee-plugin-skype/usr
 	mv debian/skyped/usr/lib debian/bitlbee-plugin-skype/usr
@@ -107,7 +113,13 @@ binary-common:
 	# Hardy and Lenny are deprecated.
 	for p in bitlbee bitlbee-libpurple bitlbee-dev bitlbee-plugin-otr; do rm -r debian/$$p/usr/share/doc/$$p && ln -s bitlbee-common debian/$$p/usr/share/doc/$$p || true; done
 	dh_installdebconf
+ifeq ($(HAS_DH_SYSTEMD),1)
+	dh_systemd_enable
 	dh_installinit --init-script=bitlbee
+	dh_systemd_start
+else
+	dh_installinit --init-script=bitlbee
+endif
 	dh_installman
 	dh_lintian
 	dh_strip

--- a/init/bitlbee.service.in
+++ b/init/bitlbee.service.in
@@ -4,6 +4,7 @@ After=syslog.target
 
 [Service]
 ExecStart=@sbindir@bitlbee -F -n
+KillMode=process
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
I'm using the debhelper version (9.20131227) to avoid depending on dh_systemd for debian wheezy and ubuntu precise. If it's older than that, it's probably a distro without dh_systemd.

----

@jelmer @Wilm0r review the debianness of this plz

Tested in a debian jessie container. Getting a deb build environment working in that took way too long, and the server I had for this purpose is dead, so i'm not going to do it for every damn distro. Wilmer's pbuilder can handle this.

```
# dpkg -i bitlbee-common_3.4.2-1_all.deb bitlbee_3.4.2-1_amd64.deb
Selecting previously unselected package bitlbee-common.
(Reading database ... 30688 files and directories currently installed.)
Preparing to unpack bitlbee-common_3.4.2-1_all.deb ...
Unpacking bitlbee-common (3.4.2-1) ...
Selecting previously unselected package bitlbee.
Preparing to unpack bitlbee_3.4.2-1_amd64.deb ...
Unpacking bitlbee (3.4.2-1) ...
Setting up bitlbee-common (3.4.2-1) ...
Adding system user `bitlbee' (UID 106) ...
Adding new group `bitlbee' (GID 111) ...
Adding new user `bitlbee' (UID 106) with group `bitlbee' ...
Creating home directory `/var/lib/bitlbee/' ...
Setting up bitlbee (3.4.2-1) ...
Processing triggers for systemd (215-17+deb8u4) ...
Processing triggers for man-db (2.7.0.2-5) ...

# systemctl status bitlbee
● bitlbee.service - BitlBee IRC/IM gateway
   Loaded: loaded (/lib/systemd/system/bitlbee.service; enabled)
   Active: active (running) since Sun 2016-06-12 08:51:20 UTC; 6s ago
 Main PID: 6394 (bitlbee)
   CGroup: /docker/43d1b386f114bc43dbb2134052651205433a6217f246616903214b32a2036726/system.slice/bitlbee.service
           └─6394 /usr/sbin/bitlbee -F -n

Jun 12 08:51:20 43d1b386f114 systemd[1]: Started BitlBee IRC/IM gateway.
```