### PR TITLE
Added an interface for the listing of existing chatrooms

### DIFF
--- a/bitlbee.h
+++ b/bitlbee.h
@@ -172,6 +172,7 @@ void root_command_string(irc_t *irc, char *command);
 void root_command(irc_t *irc, char *command[]);
 gboolean root_command_add(const char *command, int params, void (*func)(irc_t *, char **args), int flags);
 gboolean cmd_identify_finish(gpointer data, gint fd, b_input_condition cond);
+void cmd_chat_list_finish(struct im_connection *ic);
 gboolean bitlbee_shutdown(gpointer data, gint fd, b_input_condition cond);
 
 char *set_eval_root_nick(set_t *set, char *new_nick);

--- a/doc/user-guide/commands.xml
+++ b/doc/user-guide/commands.xml
@@ -263,7 +263,7 @@
 		</description>
 
 		<bitlbee-command name="add">
-			<syntax>chat add &lt;account id&gt; &lt;room&gt; [&lt;channel&gt;]</syntax>
+			<syntax>chat add &lt;account id&gt; &lt;room|!index&gt; [&lt;channel&gt;]</syntax>
 
 			<description>
 				<para>
@@ -279,6 +279,16 @@
 				</para>
 			</description>
 
+		</bitlbee-command>
+
+		<bitlbee-command name="list">
+			<syntax>chat list &lt;account id&gt; [&lt;server&gt;]</syntax>
+
+			<description>
+				<para>
+					List existing chatrooms provided by an account. BitlBee needs this to propogate an internal list of chats. The existing chat can then be added with <emphasis>chat add</emphasis>.
+				</para>
+			</description>
 		</bitlbee-command>
 
 		<bitlbee-command name="with">

--- a/protocols/bee.h
+++ b/protocols/bee.h
@@ -83,6 +83,11 @@ typedef struct bee_user {
 	void *data; /* Can be used by the IM module. */
 } bee_user_t;
 
+typedef struct bee_chat_info {
+	char *title;
+	char *topic;
+} bee_chat_info_t;
+
 /* This one's mostly used so save space and make it easier (cheaper) to
    compare groups of contacts, etc. */
 typedef struct bee_group {
@@ -183,5 +188,7 @@ G_MODULE_EXPORT void imcb_chat_remove_buddy(struct groupchat *c, const char *han
 G_MODULE_EXPORT int bee_chat_msg(bee_t *bee, struct groupchat *c, const char *msg, int flags);
 G_MODULE_EXPORT struct groupchat *bee_chat_by_title(bee_t *bee, struct im_connection *ic, const char *title);
 G_MODULE_EXPORT void imcb_chat_invite(struct im_connection *ic, const char *name, const char *who, const char *msg);
+
+G_MODULE_EXPORT void bee_chat_list_finish(struct im_connection *ic);
 
 #endif /* __BEE_H__ */

--- a/protocols/bee_chat.c
+++ b/protocols/bee_chat.c
@@ -273,3 +273,8 @@ void imcb_chat_invite(struct im_connection *ic, const char *name, const char *wh
 		ic->bee->ui->chat_invite(ic->bee, bu, name, msg);
 	}
 }
+
+void bee_chat_list_finish(struct im_connection *ic)
+{
+	cmd_chat_list_finish(ic);
+}

--- a/protocols/nogaim.h
+++ b/protocols/nogaim.h
@@ -95,6 +95,7 @@ struct im_connection {
 	bee_t *bee;
 
 	GSList *groupchats;
+	GSList *chatlist;
 };
 
 struct groupchat {
@@ -261,6 +262,13 @@ struct prpl {
 
 	/* If null, equivalent to handle_cmp( ic->acc->user, who ) */
 	gboolean (* handle_is_self) (struct im_connection *, const char *who);
+
+	/* This sets/updates the im_connection->chatlist field with a
+	 * bee_chat_info_t GSList. This function should ensure the
+	 * bee_chat_list_finish() function gets called at some point
+	 * after the chat list is completely updated.
+	 */
+	void (* chat_list) (struct im_connection *, const char *server);
 
 	/* Some placeholders so eventually older plugins may cooperate with newer BitlBees. */
 	void *resv1;

--- a/protocols/purple/bpurple.h
+++ b/protocols/purple/bpurple.h
@@ -14,4 +14,10 @@ struct purple_data
     guint next_request_id;
 };
 
+struct purple_roomlist_data
+{
+    GSList *chats;
+    gint topic;
+};
+
 #endif /* !BPURPLE_H */

--- a/root_commands.c
+++ b/root_commands.c
@@ -1217,8 +1217,10 @@ static void cmd_chat(irc_t *irc, char **cmd)
 	account_t *acc;
 
 	if (g_strcasecmp(cmd[1], "add") == 0) {
-		char *channel, *s;
+		bee_chat_info_t *ci;
+		char *channel, *room, *s;
 		struct irc_channel *ic;
+		guint i;
 
 		MIN_ARGS(3);
 
@@ -1230,8 +1232,27 @@ static void cmd_chat(irc_t *irc, char **cmd)
 			return;
 		}
 
+		if (cmd[3][0] == '!') {
+			if (!acc->prpl->chat_list) {
+				irc_rootmsg(irc, "Listing chatrooms not supported on that account.");
+				return;
+			}
+
+			i = g_ascii_strtoull(cmd[3] + 1, NULL, 10);
+			ci = g_slist_nth_data(acc->ic->chatlist, i - 1);
+
+			if (ci == NULL) {
+				irc_rootmsg(irc, "Invalid chatroom index");
+				return;
+			}
+
+			room = ci->title;
+		} else {
+			room = cmd[3];
+		}
+
 		if (cmd[4] == NULL) {
-			channel = g_strdup(cmd[3]);
+			channel = g_strdup(room);
 			if ((s = strchr(channel, '@'))) {
 				*s = 0;
 			}
@@ -1251,7 +1272,7 @@ static void cmd_chat(irc_t *irc, char **cmd)
 		    set_setstr(&ic->set, "type", "chat") &&
 		    set_setstr(&ic->set, "chat_type", "room") &&
 		    set_setstr(&ic->set, "account", cmd[2]) &&
-		    set_setstr(&ic->set, "room", cmd[3])) {
+		    set_setstr(&ic->set, "room", room)) {
 			irc_rootmsg(irc, "Chatroom successfully added.");
 		} else {
 			if (ic) {
@@ -1261,6 +1282,18 @@ static void cmd_chat(irc_t *irc, char **cmd)
 			irc_rootmsg(irc, "Could not add chatroom.");
 		}
 		g_free(channel);
+	} else if (g_strcasecmp(cmd[1], "list") == 0) {
+		MIN_ARGS(2);
+
+		if (!(acc = account_get(irc->b, cmd[2]))) {
+			irc_rootmsg(irc, "Invalid account");
+			return;
+		} else if (!acc->prpl->chat_list) {
+			irc_rootmsg(irc, "Listing chatrooms not supported on that account.");
+			return;
+		}
+
+		acc->prpl->chat_list(acc->ic, cmd[3]);
 	} else if (g_strcasecmp(cmd[1], "with") == 0) {
 		irc_user_t *iu;
 
@@ -1275,8 +1308,7 @@ static void cmd_chat(irc_t *irc, char **cmd)
 		} else {
 			irc_rootmsg(irc, "Can't open a groupchat with %s.", cmd[2]);
 		}
-	} else if (g_strcasecmp(cmd[1], "list") == 0 ||
-	           g_strcasecmp(cmd[1], "set") == 0 ||
+	} else if (g_strcasecmp(cmd[1], "set") == 0 ||
 	           g_strcasecmp(cmd[1], "del") == 0) {
 		irc_rootmsg(irc,
 		            "Warning: The \002chat\002 command was mostly replaced with the \002channel\002 command.");
@@ -1286,6 +1318,39 @@ static void cmd_chat(irc_t *irc, char **cmd)
 		            "Unknown command: %s %s. Please use \x02help commands\x02 to get a list of available commands.", "chat",
 		            cmd[1]);
 	}
+}
+
+void cmd_chat_list_finish(struct im_connection *ic)
+{
+	account_t *acc = ic->acc;
+	bee_chat_info_t *ci;
+	char *hformat, *iformat, *topic;
+	GSList *l;
+	guint i = 0;
+	irc_t *irc = ic->bee->ui_data;
+
+	if (ic->chatlist == NULL) {
+		irc_rootmsg(irc, "No existing chatrooms");
+		return;
+	}
+
+	if (strchr(irc->umode, 'b') != NULL) {
+		hformat = "%s\t%s\t%s";
+		iformat = "%u\t%s\t%s";
+	} else {
+		hformat = "%s  %-20s  %s";
+		iformat = "%5u  %-20.20s  %s";
+	}
+
+	irc_rootmsg(irc, hformat, "Index", "Title", "Topic");
+
+	for (l = ic->chatlist; l; l = l->next) {
+		ci = l->data;
+		topic = ci->topic ? ci->topic : "";
+		irc_rootmsg(irc, iformat, ++i, ci->title, topic);
+	}
+
+	irc_rootmsg(irc, "%u %s chatrooms", i, acc->tag);
 }
 
 static void cmd_group(irc_t *irc, char **cmd)

--- a/root_commands.c
+++ b/root_commands.c
@@ -1233,7 +1233,10 @@ static void cmd_chat(irc_t *irc, char **cmd)
 		}
 
 		if (cmd[3][0] == '!') {
-			if (!acc->prpl->chat_list) {
+			if (!acc->ic || !(acc->ic->flags & OPT_LOGGED_IN)) {
+				irc_rootmsg(irc, "Not logged in to account.");
+				return;
+			} else if (!acc->prpl->chat_list) {
 				irc_rootmsg(irc, "Listing chatrooms not supported on that account.");
 				return;
 			}
@@ -1287,6 +1290,9 @@ static void cmd_chat(irc_t *irc, char **cmd)
 
 		if (!(acc = account_get(irc->b, cmd[2]))) {
 			irc_rootmsg(irc, "Invalid account");
+			return;
+		} else if (!acc->ic || !(acc->ic->flags & OPT_LOGGED_IN)) {
+			irc_rootmsg(irc, "Not logged in to account.");
 			return;
 		} else if (!acc->prpl->chat_list) {
 			irc_rootmsg(irc, "Listing chatrooms not supported on that account.");


### PR DESCRIPTION
Several protocols can provide a list of existing chatrooms that a user
is able join. This is crucial for the usage of several protocols, most
notably Purple and Facebook.

Plugins wishing to support this extended functionality must implement
the new prpl->chat_list() function. This implemented function will in
most cases send a remote request for the list of chatrooms. Once the
list of chatrooms is obtained, a bee_chat_info_t GSList must be created
and assigned to the im_connection->chatlist field. Then a call to the
bee_chat_list_finish() is needed to display the list to the user.

The chat list is maintained entirely by the plugin, so it is important
to ensure all pointers related to the chat list remain valid until the
chat list is set to NULL. This list is used internally by bitlbee to
calculate indexes, which then allows the user to join a chat with an
index, rather than some random identifier. It also important to ensure
the list is properly freed whenever it is updated, or when the account
is disconnect via the prpl->logout() function.

On the user interface side of things, the 'chat list' subcommand was
recommissioned. For a user to list the existing chat rooms:

    chat list <account id>

Afterwards a user can join a chatroom in the list with its index. This
extends the functionality of the 'chat add' subcommand by adding in
support for the exclamation point operator to denote an index.

    chat add <account id> !<index> [channel]