### PR TITLE
help: Briefly explain meaning of special, fix spaces

### DIFF
--- a/doc/user-guide/commands.xml
+++ b/doc/user-guide/commands.xml
@@ -1508,8 +1508,8 @@
 				Comma-separated list of statuses of users you want in the channel,
 				and any modes they should have. The following statuses are currently
 				recognised: <emphasis>online</emphasis> (i.e. available, not
-				away), <emphasis>special</emphasis>, <emphasis>away</emphasis>,
-				and <emphasis>offline</emphasis>.
+				away), <emphasis>special</emphasis> (specific to the protocol),
+				<emphasis>away</emphasis>, and <emphasis>offline</emphasis>.
 			</para>
 			
 			<para>

--- a/doc/user-guide/commands.xml
+++ b/doc/user-guide/commands.xml
@@ -1508,14 +1508,14 @@
 				Comma-separated list of statuses of users you want in the channel,
 				and any modes they should have. The following statuses are currently
 				recognised: <emphasis>online</emphasis> (i.e. available, not
-				away), <emphasis>special</emphasis> (specific to the protocol),
+				away), <emphasis>special</emphasis> (specific to the protocol), 
 				<emphasis>away</emphasis>, and <emphasis>offline</emphasis>.
 			</para>
 			
 			<para>
 				If a status is followed by a valid channel mode character
 				(@, % or +), it will be given to users with that status.
-				For example, <emphasis>online@,special%,away+,offline</emphasis>
+				For example, <emphasis>online@,special%,away+,offline</emphasis> 
 				will show all users in the channel. Online people will
 				have +o, people who are online but away will have +v,
 				and others will have no special modes.


### PR DESCRIPTION
## In short
* Add brief note on ```special``` for ```help set show_users```
 * Avoid specific examples (*e.g. playing a game on Steam*) as implementation is protocol-specific
* Manually add spaces after two ```<emphasis>``` tags to work around a ```genhelp.py``` bug
 * Problem most likely in ```NORMALIZE_RE``` reg-ex [```([^<>\s\t])[\s\t]+([^<>\s\t])``` as shown here](https://regex101.com/r/uK3qY1/1 )

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★☆☆ *1/3* | User-facing, slightly better explanation of a more obscure setting
Risk | ★☆☆ *1/3* | Knowledge offers potential for greater confusion, may cause revolts
Intrusiveness | ★☆☆ *1/3* | Small set of changes, shouldn't interfere with other pull requests

## Example
*User nickname is ```digitalcircuit```, control channel nickname is ```root```.  Newlines added for readability.*
### Before
```
<digitalcircuit> help set show_users
<root> Type: string
<root> Scope: channel
<root> Default: online+,special%,away
<root>  
<root> Comma-separated list of statuses of users you want in the channel, and any modes
they should have. The following statuses are currently recognised: online (i.e.
available, not away), special, away, and offline.
<root>  
<root> If a status is followed by a valid channel mode character (@, % or +), it will
be given to users with that status. For example, online@,special%,away+,offlinewill
show all users in the channel. Online people will have +o, people who are online but
away will have +v, and others will have no special modes.
```
### After
```
<digitalcircuit> help set show_users
<root> Type: string
<root> Scope: channel
<root> Default: online+,special%,away
<root>  
<root> Comma-separated list of statuses of users you want in the channel, and any modes 
they should have. The following statuses are currently recognised: online (i.e.
available, not away), special (specific to the protocol), away, and offline.
<root>  
<root> If a status is followed by a valid channel mode character (@, % or +), it will
be given to users with that status. For example, online@,special%,away+,offline will
show all users in the channel. Online people will have +o, people who are online but
away will have +v, and others will have no special modes.
```