### PR TITLE
twitter: Changes to 140 char limit detection

### DIFF
--- a/protocols/twitter/twitter.c
+++ b/protocols/twitter/twitter.c
@@ -462,6 +462,7 @@ int twitter_url_len_diff(gchar *msg, unsigned int target_len)
 	int url_len_diff = 0;
 
 	static GRegex *regex = NULL;
+	static GRegex *name_regex = NULL;
 	GMatchInfo *match_info;
 
 	if (regex == NULL) {
@@ -477,6 +478,21 @@ int twitter_url_len_diff(gchar *msg, unsigned int target_len)
 
 		g_free(url);
 		g_match_info_next(match_info, NULL);
+	}
+	g_match_info_free(match_info);
+
+	if (name_regex == NULL) {
+		name_regex = g_regex_new("^@\\w+( @\\w+)?", 0, 0, NULL);
+	}
+
+	g_regex_match(name_regex, msg, 0, &match_info);
+	if (g_match_info_matches(match_info)) {
+		gchar *url;
+
+		url = g_match_info_fetch(match_info, 0);
+		url_len_diff += target_len - g_utf8_strlen(url, -1);
+
+		g_free(url);
 	}
 	g_match_info_free(match_info);
 


### PR DESCRIPTION
As of the 19th of September, Twitter will apparently no longer consider
@usernames at the start of a tweet as part of the 140 characters. URLs are
already ignored when determining this limit, so this patch uses a similar
approach to not counting @usernames.

It's important to note that these are only ignored if at the start of the
tweet, but there's no hard source from Twitter on how this is calculated. For
now, I'm assuming that "@username" at the start is skipping, as is
"@username1 @username2" and so-on.

I don't think this should be merged in until we have a definite source on what is or is not counted, but at least this is a start to adopting this change.

Source: http://www.theverge.com/2016/9/12/12891562/twitter-tweets-140-characters-expand-photos