### PR TITLE
misc.c: Return early in strip_html if the input is zero length

### DIFF
--- a/lib/misc.c
+++ b/lib/misc.c
@@ -162,6 +162,13 @@ void strip_html(char *in)
 
 	memset(out, 0, sizeof(out));
 
+	if (strlen(in) == 0) {
+		/* If strlen(in) == 0, there's no point processing it. Also, the strcpy at the end
+		   of this function will EXC_BAD_ACCESS because strlen(out) == 1. So just bail out
+		   now. */
+		return;
+	}
+
 	while (*in) {
 		if (*in == '<' && (g_ascii_isalpha(*(in + 1)) || *(in + 1) == '/')) {
 			/* If in points at a < and in+1 points at a letter or a slash, this is probably


### PR DESCRIPTION
If `strip_html` is `always`, and the client tries to join an XMPP (and maybe others) groupchat where the topic is blank or empty, `strip_html` calls strcpy to copy a 1-byte array to a 0-byte array. This just returns early in strip_html if `in` is zero-length to avoid the issue altogether.

I'm not sure if there's anything else to provide with this, but let me know if so and I'm happy to do what I can.