### PR TITLE
install script done

### DIFF
--- a/install.bash
+++ b/install.bash
@@ -1,5 +1,5 @@
 #!/bin/bash
 apt update
-apt install libssl-dev
+apt install libssl-dev pkg-config libglib2.0-dev
 ./configure --ssl=openssl && make && make install && make install-etc && make install-dev
 

--- a/install.bash
+++ b/install.bash
@@ -1,0 +1,5 @@
+#!/bin/bash
+apt update
+apt install libssl-dev
+./configure --ssl=openssl && make && make install && make install-etc && make install-dev
+


### PR DESCRIPTION
After recognizing that gnutls version is compiling and running without error messages but is NOT able to make a working tls connection, I wrote this script to install openssl version of bitlbee with all dependencies. BTW the official bitlbee package in ubuntu 14.04 and debian wheezy are also broken. After jabber server answers to proceed tls connection, bitlbee does not answer and says only "Login error: Could not connect to server". Use this install script to avoid this error.