### PR TITLE
purple: allow libpurple message processing before passing to bitlbee.

### DIFF
--- a/protocols/purple/purple.c
+++ b/protocols/purple/purple.c
@@ -1027,46 +1027,31 @@ void prplcb_conv_del_users(PurpleConversation *conv, GList *cbuddies)
 	}
 }
 
-/* Generic handler for IM or chat messages, covers write_chat, write_im and write_conv */
-static void handle_conv_msg(PurpleConversation *conv, const char *who, const char *message_, guint32 bee_flags, time_t mtime)
+/* Handles write_conv. Passes messages received by purple further up to bitlbee
+ * There are more events which might be handled in the future, but some are tricky.
+ * (images look like <img id="123">, what do i do with that?) */
+static void prplcb_conv_write(PurpleConversation *conv, const char *who, const char *alias, const char *message_,
+                              PurpleMessageFlags flags, time_t mtime)
 {
+	if (flags & PURPLE_MESSAGE_SEND) {
+		return;
+	}
 	struct im_connection *ic = purple_ic_by_pa(conv->account);
 	struct groupchat *gc = conv->ui_data;
 	char *message = g_strdup(message_);
 	PurpleBuddy *buddy;
-
 	buddy = purple_find_buddy(conv->account, who);
 	if (buddy != NULL) {
 		who = purple_buddy_get_name(buddy);
 	}
 
 	if (conv->type == PURPLE_CONV_TYPE_IM) {
-		imcb_buddy_msg(ic, who, message, bee_flags, mtime);
+		imcb_buddy_msg(ic, who, message, 0, mtime);
 	} else if (gc) {
-		imcb_chat_msg(gc, who, message, bee_flags, mtime);
+		imcb_chat_msg(gc, who, message, 0, mtime);
 	}
 
 	g_free(message);
-}
-
-/* Handles write_im and write_chat. Removes echoes of locally sent messages */
-static void prplcb_conv_msg(PurpleConversation *conv, const char *who, const char *message, PurpleMessageFlags flags, time_t mtime)
-{
-	if (!(flags & PURPLE_MESSAGE_SEND)) {
-		handle_conv_msg(conv, who, message, 0, mtime);
-	}
-}
-
-/* Handles write_conv. Only passes self messages from other locations through.
- * That is, only writes of PURPLE_MESSAGE_SEND.
- * There are more events which might be handled in the future, but some are tricky.
- * (images look like <img id="123">, what do i do with that?) */
-static void prplcb_conv_write(PurpleConversation *conv, const char *who, const char *alias, const char *message,
-                              PurpleMessageFlags flags, time_t mtime)
-{
-	if (flags & PURPLE_MESSAGE_SEND) {
-		handle_conv_msg(conv, who, message, OPT_SELFMESSAGE, mtime);
-	}
 }
 
 /* No, this is not a ui_op but a signal. */
@@ -1099,8 +1084,8 @@ static PurpleConversationUiOps bee_conv_uiops =
 {
 	prplcb_conv_new,           /* create_conversation  */
 	prplcb_conv_free,          /* destroy_conversation */
-	prplcb_conv_msg,           /* write_chat           */
-	prplcb_conv_msg,           /* write_im             */
+	NULL,                      /* write_chat           */
+	NULL,                      /* write_im             */
 	prplcb_conv_write,         /* write_conv           */
 	prplcb_conv_add_users,     /* chat_add_users       */
 	NULL,                      /* chat_rename_user     */


### PR DESCRIPTION
I've made this mostly for logging. However it generally allows a message to pass through purple processing which at the moment  also emits a purple dbus signal. 