### PR TITLE
[debian] Replace netstat by ss

### DIFF
--- a/debian/bitlbee-common.config
+++ b/debian/bitlbee-common.config
@@ -12,13 +12,7 @@ if [ -n "$BITLBEE_PORT" ]; then
 else
 	db_get bitlbee/serveport
 	if [ "$RET" = "stillhavetoask" ]; then
-		listens=$(netstat -ltn | awk '{print $4}')
-		for port in 6667 6666 6668 6669; do
-			if [ $(expr "$listens " : ".*:$port\s") = "0" ]; then
-				break
-			fi
-		done
-		db_set bitlbee/serveport $port;
+		db_set bitlbee/serveport 6667;
 	fi
 fi
 

--- a/debian/control
+++ b/debian/control
@@ -38,7 +38,7 @@ Description: IRC to other chat networks gateway (using libpurple)
 
 Package: bitlbee-common
 Architecture: all
-Depends: ${misc:Depends}, net-tools, adduser
+Depends: ${misc:Depends}, adduser
 Replaces: bitlbee
 Description: IRC to other chat networks gateway (common files/docs)
  This program can be used as an IRC server which forwards everything you


### PR DESCRIPTION
Also replace the dependency on net-tools by iproute2.
See: https://lists.debian.org/debian-devel/2016/12/msg00604.html