### PR TITLE
Use NI_MAXHOST rather than HOST_NAME_MAX for host lengths.

### DIFF
--- a/dcc.c
+++ b/dcc.c
@@ -91,7 +91,7 @@ file_transfer_t *dccs_send_start(struct im_connection *ic, irc_user_t *iu, const
 	irc_t *irc = (irc_t *) ic->bee->ui_data;
 	struct sockaddr_storage saddr;
 	char *errmsg;
-	char host[HOST_NAME_MAX];
+	char host[NI_MAXHOST];
 	char port[6];
 
 	if (file_size > global.conf->ft_max_size) {

--- a/lib/ftutil.c
+++ b/lib/ftutil.c
@@ -62,13 +62,13 @@ int ft_listen(struct sockaddr_storage *saddr_ptr, char *host, char *port, int co
 		if (scolon) {
 			if (for_bitlbee_client) {
 				*scolon = '\0';
-				strncpy(host, ftlisten, HOST_NAME_MAX);
+				strncpy(host, ftlisten, NI_MAXHOST);
 				*scolon = ';';
 			} else {
-				strncpy(host, scolon + 1, HOST_NAME_MAX);
+				strncpy(host, scolon + 1, NI_MAXHOST);
 			}
 		} else {
-			strncpy(host, ftlisten, HOST_NAME_MAX);
+			strncpy(host, ftlisten, NI_MAXHOST);
 		}
 
 		if ((colon = strchr(host, ':'))) {
@@ -77,13 +77,13 @@ int ft_listen(struct sockaddr_storage *saddr_ptr, char *host, char *port, int co
 		}
 	} else if (copy_fd >= 0 && getsockname(copy_fd, (struct sockaddr*) &saddrs, &ssize) == 0 &&
 	           (saddrs.ss_family == AF_INET || saddrs.ss_family == AF_INET6) &&
-	           getnameinfo((struct sockaddr*) &saddrs, ssize, host, HOST_NAME_MAX,
+	           getnameinfo((struct sockaddr*) &saddrs, ssize, host, NI_MAXHOST,
 	                       NULL, 0, NI_NUMERICHOST) == 0) {
 		/* We just took our local address on copy_fd, which is likely to be a
 		   sensible address from which we can do a file transfer now - the
 		   most sensible we can get easily. */
 	} else {
-		ASSERTSOCKOP(gethostname(host, HOST_NAME_MAX + 1), "gethostname()");
+		ASSERTSOCKOP(gethostname(host, NI_MAXHOST), "gethostname()");
 	}
 
 	memset(&hints, 0, sizeof(struct addrinfo));
@@ -108,7 +108,7 @@ int ft_listen(struct sockaddr_storage *saddr_ptr, char *host, char *port, int co
 	if (!inet_ntop(saddr->ss_family, saddr->ss_family == AF_INET ?
 	               ( void * ) &(( struct sockaddr_in * ) saddr)->sin_addr.s_addr :
 	               ( void * ) &(( struct sockaddr_in6 * ) saddr)->sin6_addr.s6_addr,
-	               host, HOST_NAME_MAX)) {
+	               host, NI_MAXHOST)) {
 		strcpy(errmsg, "inet_ntop failed on listening socket");
 		return -1;
 	}
@@ -127,7 +127,7 @@ int ft_listen(struct sockaddr_storage *saddr_ptr, char *host, char *port, int co
 	}
 
 	/* I hate static-length strings.. */
-	host[HOST_NAME_MAX - 1] = '\0';
+	host[NI_MAXHOST - 1] = '\0';
 	port[5] = '\0';
 
 	return fd;

--- a/lib/ftutil.h
+++ b/lib/ftutil.h
@@ -25,17 +25,7 @@
 #define AI_NUMERICSERV 0x0400   /* Don't use name resolution.  */
 #endif
 
-/* Some ifdefs for ulibc and apparently also BSD (Thanks to Whoopie) */
-#ifndef HOST_NAME_MAX
-#include <sys/param.h>
-#ifdef MAXHOSTNAMELEN
-#define HOST_NAME_MAX MAXHOSTNAMELEN
-#else
-#define HOST_NAME_MAX 255
-#endif
-#endif
-
 /* This function should be used with care. host should be AT LEAST a
-   char[HOST_NAME_MAX+1] and port AT LEAST a char[6]. */
+   char[NI_MAXHOST+1] and port AT LEAST a char[6]. */
 int ft_listen(struct sockaddr_storage *saddr_ptr, char *host, char *port, int copy_fd, int for_bitlbee_client,
               char **errptr);

--- a/protocols/jabber/s5bytestream.c
+++ b/protocols/jabber/s5bytestream.c
@@ -887,7 +887,7 @@ void jabber_si_set_proxies(struct bs_transfer *bt)
 	char *proxysetting = g_strdup(set_getstr(&tf->ic->acc->set, "proxy"));
 	char *proxy, *next, *errmsg = NULL;
 	char port[6];
-	char host[HOST_NAME_MAX + 1];
+	char host[NI_MAXHOST + 1];
 	jabber_streamhost_t *sh, *sh2;
 	GSList *streamhosts = jd->streamhosts;
 


### PR DESCRIPTION
This constant is always available and meant to be used with
getnameinfo().

This fixes the build on Debian GNU/kFreeBSD. See https://buildd.debian.org/status/package.php?p=bitlbee