### PR TITLE
Third argument to socket/socketpair fails on OS X

### DIFF
--- a/ipc.c
+++ b/ipc.c
@@ -897,7 +897,7 @@ int ipc_master_listen_socket()
 	un_addr.sun_family = AF_UNIX;
 	strcpy(un_addr.sun_path, IPCSOCKET);
 
-	serversock = socket(AF_UNIX, SOCK_STREAM, PF_UNIX);
+	serversock = socket(AF_UNIX, SOCK_STREAM, 0);
 
 	if (serversock == -1) {
 		log_message(LOGLVL_WARNING, "Unable to create UNIX socket: %s", strerror(errno));

--- a/tests/check.c
+++ b/tests/check.c
@@ -13,7 +13,7 @@ gboolean g_io_channel_pair(GIOChannel **ch1, GIOChannel **ch2)
 {
 	int sock[2];
 
-	if (socketpair(AF_UNIX, SOCK_STREAM, PF_UNIX, sock) < 0) {
+	if (socketpair(AF_UNIX, SOCK_STREAM, 0, sock) < 0) {
 		perror("socketpair");
 		return FALSE;
 	}


### PR DESCRIPTION
I noticed that with bitlbee-3.5.1 that 'make check' would fail under Sierra.  After some investigation it appears that Sierra socket handling must have been made more strict.  To test, I ran this program under Linux and OS X.

```
#include <stdio.h>
#include <stdlib.h>

#include <sys/socket.h>

int main (int argc, char **argv) {
  int i;
  for (i = 0; i < 5; i++)
    {
      printf ("start with %d\n",i);
      if (socket (AF_UNIX, SOCK_STREAM, i) < 0) {
        perror("socket");
      }
    }
  exit(0);
}
```

Under Linux a protocol of ```0``` or ```1``` was successful, under OS X only ```0``` was successful.  According to the manpages, one should use ```0``` for the third argument (which is treated as using the default for the given family), and according to Stevens the only time a non-zero value makes sense is when using raw sockets.  I found that within bitlbee that sometimes ```0``` is used and other times (like in the IPC and test code) it was not.  This should make it consistent.