### PR TITLE
twitter: @mention the right people when replying

### DIFF
--- a/protocols/twitter/twitter.h
+++ b/protocols/twitter/twitter.h
@@ -105,6 +105,7 @@ struct twitter_log_data {
 	/* DANGER: bu can be a dead pointer. Check it first.
 	 * twitter_message_id_from_command_arg() will do this. */
 	struct bee_user *bu;
+	gchar *text;
 };
 
 /**

--- a/protocols/twitter/twitter_lib.c
+++ b/protocols/twitter/twitter_lib.c
@@ -837,6 +837,10 @@ static char *twitter_msg_add_id(struct im_connection *ic,
 	td->log_id = (td->log_id + 1) % TWITTER_LOG_LENGTH;
 	td->log[td->log_id].id = txs->id;
 	td->log[td->log_id].bu = bee_user_by_handle(ic->bee, ic, txs->user->screen_name);
+	if (td->log[td->log_id].text) {
+		g_free(td->log[td->log_id].text);
+	}
+	td->log[td->log_id].text = g_strdup(txs->text);
 
 	/* This is all getting hairy. :-( If we RT'ed something ourselves,
 	   remember OUR id instead so undo will work. In other cases, the


### PR DESCRIPTION
The previous approach was simply to @ the author of the replied-to
tweet. This is unintuitive
    a) when replying to a tweet that mentions
        several people, in which case they are cut off; and
    b) if you reply to a previous reply you made, in which case you @
        yourself and the intended recipient(s) won't see it.

This commit introduces a function twitter_format_reply to determine
the correct @mention string for the start of your tweet, based on the
original tweet you are replying to. This preserves all mentionees from
the original tweet, removing ourselves if present and making sure
the original tweet's author comes first (if not us).

This patch closes Trac issues #1289, #1251.