### PR TITLE
Add PROXY command so stunnel connections look better

### DIFF
--- a/debian/copyright
+++ b/debian/copyright
@@ -16,8 +16,8 @@ Bits of third party code, also (L)GPLed:
 Other license (but GPL-compatible):
 * lib/json.[ch] is from <https://github.com/udp/json-parser> and licensed
   under the modified BSD license.
-* reverse_lookup() from lib/misc.c is from OpenSSH and licenced under
-  the BSD-3-clause licence.
+* lib/canohost.[ch] is from OpenSSH and licenced under the BSD-3-clause
+  licence.
 
 
 BitlBee License:

--- a/debian/copyright
+++ b/debian/copyright
@@ -16,6 +16,8 @@ Bits of third party code, also (L)GPLed:
 Other license (but GPL-compatible):
 * lib/json.[ch] is from <https://github.com/udp/json-parser> and licensed
   under the modified BSD license.
+* reverse_lookup() from lib/misc.c is from OpenSSH and licenced under
+  the BSD-3-clause licence.
 
 
 BitlBee License:

--- a/irc.c
+++ b/irc.c
@@ -67,21 +67,11 @@ irc_t *irc_new(int fd)
 	if (global.conf->hostname) {
 		myhost = g_strdup(global.conf->hostname);
 	} else if (getsockname(irc->fd, (struct sockaddr*) &sock, &socklen) == 0) {
-		char buf[NI_MAXHOST + 1];
-
-		if (getnameinfo((struct sockaddr *) &sock, socklen, buf,
-		                NI_MAXHOST, NULL, 0, 0) == 0) {
-			myhost = g_strdup(ipv6_unwrap(buf));
-		}
+		myhost = reverse_lookup((struct sockaddr*) &sock, socklen);
 	}
 
 	if (getpeername(irc->fd, (struct sockaddr*) &sock, &socklen) == 0) {
-		char buf[NI_MAXHOST + 1];
-
-		if (getnameinfo((struct sockaddr *) &sock, socklen, buf,
-		                NI_MAXHOST, NULL, 0, 0) == 0) {
-			host = g_strdup(ipv6_unwrap(buf));
-		}
+		host = reverse_lookup((struct sockaddr*) &sock, socklen);
 	}
 
 	if (host == NULL) {

--- a/irc.c
+++ b/irc.c
@@ -24,6 +24,7 @@
 */
 
 #include "bitlbee.h"
+#include "canohost.h"
 #include "ipc.h"
 #include "dcc.h"
 #include "lib/ssl_client.h"

--- a/irc.h
+++ b/irc.h
@@ -26,6 +26,8 @@
 #ifndef _IRC_H
 #define _IRC_H
 
+#include <sys/socket.h>
+
 #define IRC_MAX_LINE 512
 #define IRC_MAX_ARGS 16
 #define IRC_WORD_WRAP 425
@@ -270,6 +272,7 @@ extern GSList *irc_plugins; /* struct irc_plugin */
 extern GSList *irc_connection_list;
 
 irc_t *irc_new(int fd);
+void irc_set_hosts(irc_t *irc, const struct sockaddr *remote_addr, const socklen_t remote_addrlen);
 void irc_abort(irc_t *irc, int immed, char *format, ...) G_GNUC_PRINTF(3, 4);
 void irc_free(irc_t *irc);
 void irc_setpass(irc_t *irc, const char *pass);

--- a/irc_commands.c
+++ b/irc_commands.c
@@ -25,6 +25,7 @@
 
 #define BITLBEE_CORE
 #include "bitlbee.h"
+#include "canohost.h"
 #include "help.h"
 #include "ipc.h"
 #include "base64.h"

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -12,7 +12,7 @@ _SRCDIR_ := $(_SRCDIR_)lib/
 endif
 
 # [SH] Program variables
-objects = arc.o base64.o $(EVENT_HANDLER) ftutil.o http_client.o ini.o json.o json_util.o md5.o misc.o oauth.o oauth2.o proxy.o sha1.o $(SSL_CLIENT) url.o xmltree.o ns_parse.o
+objects = arc.o base64.o canohost.o $(EVENT_HANDLER) ftutil.o http_client.o ini.o json.o json_util.o md5.o misc.o oauth.o oauth2.o proxy.o sha1.o $(SSL_CLIENT) url.o xmltree.o ns_parse.o
 
 LFLAGS += -r
 

--- a/lib/canohost.c
+++ b/lib/canohost.c
@@ -1,0 +1,140 @@
+  /********************************************************************\
+  * BitlBee -- An IRC to other IM-networks gateway                     *
+  *                                                                    *
+  * Copyright 2002-2017 Wilmer van der Gaast and others                *
+  \********************************************************************/
+
+/*
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License with
+  the Debian GNU/Linux distribution in /usr/share/common-licenses/GPL;
+  if not, write to the Free Software Foundation, Inc., 51 Franklin St.,
+  Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+/* These two functions, with some modifications, taken from OpenSSH:
+ *
+ * $OpenBSD: canohost.c,v 1.73 2016/03/07 19:02:43 djm Exp
+ *
+ * Author: Tatu Ylonen <ylo@cs.hut.fi>
+ * Copyright (c) 1995 Tatu Ylonen <ylo@cs.hut.fi>, Espoo, Finland
+ *                    All rights reserved
+ * Functions for returning the canonical host name of the remote site.
+ *
+ * As far as I am concerned, the code I have written for this software
+ * can be used freely for any purpose.  Any derived versions of this
+ * software must be clearly marked as such, and if the derived work is
+ * incompatible with the protocol description in the RFC file, it must be
+ * called by a name other than "ssh" or "Secure Shell".
+ */
+
+#include "canohost.h"
+
+char *reverse_lookup(const struct sockaddr *from_, const socklen_t fromlen_)
+{
+	struct sockaddr_storage from;
+	socklen_t fromlen;
+	struct addrinfo hints, *ai, *aitop;
+	char name[NI_MAXHOST], ntop2[NI_MAXHOST];
+	char ntop[INET6_ADDRSTRLEN];
+
+	fromlen = sizeof(from);
+	memset(&from, 0, sizeof(from));
+	memcpy(&from, from_, fromlen_);
+	ipv64_normalise_mapped(&from, &fromlen);
+	if (from.ss_family == AF_INET6) {
+		fromlen = sizeof(struct sockaddr_in6);
+	}
+
+	if (getnameinfo((struct sockaddr *)&from, fromlen, ntop, sizeof(ntop),
+	    NULL, 0, NI_NUMERICHOST) != 0) {
+		return NULL;
+	}
+
+	/* Map the IP address to a host name. */
+	if (getnameinfo((struct sockaddr *)&from, fromlen, name, sizeof(name),
+	    NULL, 0, NI_NAMEREQD) != 0) {
+		/* Host name not found.  Use ip address. */
+		return g_strdup(ntop);
+	}
+
+	/*
+	 * if reverse lookup result looks like a numeric hostname,
+	 * someone is trying to trick us by PTR record like following:
+	 *	1.1.1.10.in-addr.arpa.	IN PTR	2.3.4.5
+	 */
+	memset(&hints, 0, sizeof(hints));
+	hints.ai_socktype = SOCK_DGRAM;	/*dummy*/
+	hints.ai_flags = AI_NUMERICHOST;
+	if (getaddrinfo(name, NULL, &hints, &ai) == 0) {
+		freeaddrinfo(ai);
+		return g_strdup(ntop);
+	}
+
+	/* Names are stored in lowercase. */
+	char *tolower = g_utf8_strdown(name, -1);
+	g_snprintf(name, sizeof(name), "%s", tolower);
+	g_free(tolower);
+
+	/*
+	 * Map it back to an IP address and check that the given
+	 * address actually is an address of this host.  This is
+	 * necessary because anyone with access to a name server can
+	 * define arbitrary names for an IP address. Mapping from
+	 * name to IP address can be trusted better (but can still be
+	 * fooled if the intruder has access to the name server of
+	 * the domain).
+	 */
+	memset(&hints, 0, sizeof(hints));
+	hints.ai_family = from.ss_family;
+	hints.ai_socktype = SOCK_STREAM;
+	if (getaddrinfo(name, NULL, &hints, &aitop) != 0) {
+		return g_strdup(ntop);
+	}
+	/* Look for the address from the list of addresses. */
+	for (ai = aitop; ai; ai = ai->ai_next) {
+		if (getnameinfo(ai->ai_addr, ai->ai_addrlen, ntop2,
+		    sizeof(ntop2), NULL, 0, NI_NUMERICHOST) == 0 &&
+		    (strcmp(ntop, ntop2) == 0))
+			break;
+	}
+	freeaddrinfo(aitop);
+	/* If we reached the end of the list, the address was not there. */
+	if (ai == NULL) {
+		/* Address not found for the host name. */
+		return g_strdup(ntop);
+	}
+	return g_strdup(name);
+}
+
+void
+ipv64_normalise_mapped(struct sockaddr_storage *addr, socklen_t *len)
+{
+	struct sockaddr_in6 *a6 = (struct sockaddr_in6 *)addr;
+	struct sockaddr_in *a4 = (struct sockaddr_in *)addr;
+	struct in_addr inaddr;
+	u_int16_t port;
+
+	if (addr->ss_family != AF_INET6 ||
+	    !IN6_IS_ADDR_V4MAPPED(&a6->sin6_addr))
+		return;
+
+	memcpy(&inaddr, ((char *)&a6->sin6_addr) + 12, sizeof(inaddr));
+	port = a6->sin6_port;
+
+	memset(a4, 0, sizeof(*a4));
+
+	a4->sin_family = AF_INET;
+	*len = sizeof(*a4);
+	memcpy(&a4->sin_addr, &inaddr, sizeof(inaddr));
+	a4->sin_port = port;
+}

--- a/lib/canohost.h
+++ b/lib/canohost.h
@@ -1,0 +1,43 @@
+  /********************************************************************\
+  * BitlBee -- An IRC to other IM-networks gateway                     *
+  *                                                                    *
+  * Copyright 2002-2017 Wilmer van der Gaast and others                *
+  \********************************************************************/
+
+/*
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License with
+  the Debian GNU/Linux distribution in /usr/share/common-licenses/GPL;
+  if not, write to the Free Software Foundation, Inc., 51 Franklin St.,
+  Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+/* These two functions, with some modifications, taken from OpenSSH:
+ *
+ * $OpenBSD: canohost.c,v 1.73 2016/03/07 19:02:43 djm Exp
+ *
+ * Author: Tatu Ylonen <ylo@cs.hut.fi>
+ * Copyright (c) 1995 Tatu Ylonen <ylo@cs.hut.fi>, Espoo, Finland
+ *                    All rights reserved
+ * Functions for returning the canonical host name of the remote site.
+ *
+ * As far as I am concerned, the code I have written for this software
+ * can be used freely for any purpose.  Any derived versions of this
+ * software must be clearly marked as such, and if the derived work is
+ * incompatible with the protocol description in the RFC file, it must be
+ * called by a name other than "ssh" or "Secure Shell".
+ */
+
+#include <bitlbee.h>
+
+G_MODULE_EXPORT char *reverse_lookup(const struct sockaddr *from_, const socklen_t fromlen_);
+G_MODULE_EXPORT void ipv64_normalise_mapped(struct sockaddr_storage *addr, socklen_t *len);

--- a/lib/misc.c
+++ b/lib/misc.c
@@ -334,51 +334,6 @@ char *strip_newlines(char *source)
 	return source;
 }
 
-/* Wrap an IPv4 address into IPv6 space. Not thread-safe... */
-char *ipv6_wrap(char *src)
-{
-	static char dst[64];
-	int i;
-
-	for (i = 0; src[i]; i++) {
-		if ((src[i] < '0' || src[i] > '9') && src[i] != '.') {
-			break;
-		}
-	}
-
-	/* Hmm, it's not even an IP... */
-	if (src[i]) {
-		return src;
-	}
-
-	g_snprintf(dst, sizeof(dst), "::ffff:%s", src);
-
-	return dst;
-}
-
-/* Unwrap an IPv4 address into IPv6 space. Thread-safe, because it's very simple. :-) */
-char *ipv6_unwrap(char *src)
-{
-	int i;
-
-	if (g_strncasecmp(src, "::ffff:", 7) != 0) {
-		return src;
-	}
-
-	for (i = 7; src[i]; i++) {
-		if ((src[i] < '0' || src[i] > '9') && src[i] != '.') {
-			break;
-		}
-	}
-
-	/* Hmm, it's not even an IP... */
-	if (src[i]) {
-		return src;
-	}
-
-	return (src + 7);
-}
-
 /* Convert from one charset to another.
 
    from_cs, to_cs: Source and destination charsets

--- a/lib/misc.c
+++ b/lib/misc.c
@@ -548,6 +548,107 @@ void srv_free(struct ns_srv_reply **srv)
 	g_free(srv);
 }
 
+/* From OpenSSH 7.4p1 canohost.c" */
+char *reverse_lookup(const struct sockaddr *from_, const socklen_t fromlen_)
+{
+	struct sockaddr_storage from;
+	socklen_t fromlen;
+	struct addrinfo hints, *ai, *aitop;
+	char name[NI_MAXHOST], ntop2[NI_MAXHOST];
+	char ntop[INET6_ADDRSTRLEN];
+
+	fromlen = sizeof(from);
+	memset(&from, 0, sizeof(from));
+	memcpy(&from, from_, fromlen_);
+	ipv64_normalise_mapped(&from, &fromlen);
+	if (from.ss_family == AF_INET6) {
+		fromlen = sizeof(struct sockaddr_in6);
+	}
+
+	if (getnameinfo((struct sockaddr *)&from, fromlen, ntop, sizeof(ntop),
+	    NULL, 0, NI_NUMERICHOST) != 0) {
+		return NULL;
+	}
+
+	/* Map the IP address to a host name. */
+	if (getnameinfo((struct sockaddr *)&from, fromlen, name, sizeof(name),
+	    NULL, 0, NI_NAMEREQD) != 0) {
+		/* Host name not found.  Use ip address. */
+		return g_strdup(ntop);
+	}
+
+	/*
+	 * if reverse lookup result looks like a numeric hostname,
+	 * someone is trying to trick us by PTR record like following:
+	 *	1.1.1.10.in-addr.arpa.	IN PTR	2.3.4.5
+	 */
+	memset(&hints, 0, sizeof(hints));
+	hints.ai_socktype = SOCK_DGRAM;	/*dummy*/
+	hints.ai_flags = AI_NUMERICHOST;
+	if (getaddrinfo(name, NULL, &hints, &ai) == 0) {
+		freeaddrinfo(ai);
+		return g_strdup(ntop);
+	}
+
+	/* Names are stored in lowercase. */
+	char *tolower = g_utf8_strdown(name, -1);
+	g_snprintf(name, sizeof(name), "%s", tolower);
+	g_free(tolower);
+
+	/*
+	 * Map it back to an IP address and check that the given
+	 * address actually is an address of this host.  This is
+	 * necessary because anyone with access to a name server can
+	 * define arbitrary names for an IP address. Mapping from
+	 * name to IP address can be trusted better (but can still be
+	 * fooled if the intruder has access to the name server of
+	 * the domain).
+	 */
+	memset(&hints, 0, sizeof(hints));
+	hints.ai_family = from.ss_family;
+	hints.ai_socktype = SOCK_STREAM;
+	if (getaddrinfo(name, NULL, &hints, &aitop) != 0) {
+		return g_strdup(ntop);
+	}
+	/* Look for the address from the list of addresses. */
+	for (ai = aitop; ai; ai = ai->ai_next) {
+		if (getnameinfo(ai->ai_addr, ai->ai_addrlen, ntop2,
+		    sizeof(ntop2), NULL, 0, NI_NUMERICHOST) == 0 &&
+		    (strcmp(ntop, ntop2) == 0))
+			break;
+	}
+	freeaddrinfo(aitop);
+	/* If we reached the end of the list, the address was not there. */
+	if (ai == NULL) {
+		/* Address not found for the host name. */
+		return g_strdup(ntop);
+	}
+	return g_strdup(name);
+}
+
+void
+ipv64_normalise_mapped(struct sockaddr_storage *addr, socklen_t *len)
+{
+	struct sockaddr_in6 *a6 = (struct sockaddr_in6 *)addr;
+	struct sockaddr_in *a4 = (struct sockaddr_in *)addr;
+	struct in_addr inaddr;
+	u_int16_t port;
+
+	if (addr->ss_family != AF_INET6 ||
+	    !IN6_IS_ADDR_V4MAPPED(&a6->sin6_addr))
+		return;
+
+	memcpy(&inaddr, ((char *)&a6->sin6_addr) + 12, sizeof(inaddr));
+	port = a6->sin6_port;
+
+	memset(a4, 0, sizeof(*a4));
+
+	a4->sin_family = AF_INET;
+	*len = sizeof(*a4);
+	memcpy(&a4->sin_addr, &inaddr, sizeof(inaddr));
+	a4->sin_port = port;
+}
+
 char *word_wrap(const char *msg, int line_len)
 {
 	GString *ret = g_string_sized_new(strlen(msg) + 16);

--- a/lib/misc.h
+++ b/lib/misc.h
@@ -140,9 +140,6 @@ G_MODULE_EXPORT int bool2int(char *value);
 G_MODULE_EXPORT struct ns_srv_reply **srv_lookup(char *service, char *protocol, char *domain);
 G_MODULE_EXPORT void srv_free(struct ns_srv_reply **srv);
 
-G_MODULE_EXPORT char *reverse_lookup(const struct sockaddr *from_, const socklen_t fromlen_);
-G_MODULE_EXPORT void ipv64_normalise_mapped(struct sockaddr_storage *addr, socklen_t *len);
-
 G_MODULE_EXPORT char *word_wrap(const char *msg, int line_len);
 G_MODULE_EXPORT gboolean ssl_sockerr_again(void *ssl);
 G_MODULE_EXPORT int md5_verify_password(char *password, char *hash);

--- a/lib/misc.h
+++ b/lib/misc.h
@@ -130,9 +130,6 @@ G_MODULE_EXPORT char *escape_html(const char *html);
 G_MODULE_EXPORT void http_decode(char *s);
 G_MODULE_EXPORT void http_encode(char *s);
 
-G_MODULE_EXPORT char *ipv6_wrap(char *src);
-G_MODULE_EXPORT char *ipv6_unwrap(char *src);
-
 G_MODULE_EXPORT signed int do_iconv(char *from_cs, char *to_cs, char *src, char *dst, size_t size, size_t maxbuf);
 
 G_MODULE_EXPORT void random_bytes(unsigned char *buf, int count);

--- a/lib/misc.h
+++ b/lib/misc.h
@@ -28,6 +28,7 @@
 
 #include <gmodule.h>
 #include <time.h>
+#include <sys/socket.h>
 
 struct ns_srv_reply {
 	int prio;
@@ -141,6 +142,9 @@ G_MODULE_EXPORT int bool2int(char *value);
 
 G_MODULE_EXPORT struct ns_srv_reply **srv_lookup(char *service, char *protocol, char *domain);
 G_MODULE_EXPORT void srv_free(struct ns_srv_reply **srv);
+
+G_MODULE_EXPORT char *reverse_lookup(const struct sockaddr *from_, const socklen_t fromlen_);
+G_MODULE_EXPORT void ipv64_normalise_mapped(struct sockaddr_storage *addr, socklen_t *len);
 
 G_MODULE_EXPORT char *word_wrap(const char *msg, int line_len);
 G_MODULE_EXPORT gboolean ssl_sockerr_again(void *ssl);


### PR DESCRIPTION
Tired of all the "localhost" connections on public servers. There are horrible root-requiring hacks that make stunnel a transparent proxy, I'd rather just do this.

There's a theoretical chance of someone using this to spoof, but they'd need local-machine access so meh. It's not like this controls any ACLs..

Also, add verification of reverse lookups, so far all PTR lookup results were just used blindly.