### PR TITLE
Embed images support in libpurple

### DIFF
--- a/conf.c
+++ b/conf.c
@@ -70,6 +70,8 @@ conf_t *conf_load(int argc, char *argv[])
 	conf->ft_listen = NULL;
 	conf->protocols = NULL;
 	conf->cafile = NULL;
+	conf->web_directory = NULL;
+	conf->web_url = NULL;
 	proxytype = 0;
 
 	i = conf_loadini(conf, global.conf_file);
@@ -343,6 +345,12 @@ static int conf_loadini(conf_t *conf, char *file)
 			} else if (g_strcasecmp(ini->key, "cafile") == 0) {
 				g_free(conf->cafile);
 				conf->cafile = g_strdup(ini->value);
+			} else if (g_strcasecmp(ini->key, "web_directory") == 0) {
+				g_free(conf->web_directory);
+				conf->web_directory = g_strdup(ini->value);
+			} else if (g_strcasecmp(ini->key, "web_url") == 0) {
+				g_free(conf->web_url);
+				conf->web_url = g_strdup(ini->value);
 			} else {
 				fprintf(stderr, "Error: Unknown setting `%s` in configuration file (line %d).\n",
 				        ini->key, ini->line);

--- a/conf.h
+++ b/conf.h
@@ -55,6 +55,8 @@ typedef struct conf {
 	char *ft_listen;
 	char **protocols;
 	char *cafile;
+	char *web_directory;
+	char *web_url;
 } conf_t;
 
 G_GNUC_MALLOC conf_t *conf_load(int argc, char *argv[]);

--- a/protocols/purple/purple.c
+++ b/protocols/purple/purple.c
@@ -1212,6 +1212,7 @@ replace_images_cb (const GMatchInfo *info, GString *res, gpointer data)
 
 	g_free(id);
 	g_free(path);
+	purple_imgstore_unref(image);
 	return FALSE;
 
 error:


### PR DESCRIPTION
Parse <img> tags in messages, store the image in the filesystem and
replace the tag with a url to the image.

This add two new settings, webserver_root and webserver_url, and only
stores images if they exist.

The user should configure an http server, pointing to the webserver_root
and serving to webserver_url

Example Config:
webserver_url = http://example.com
webserver_root = /srv/bitlbee/