### PR TITLE
Fix build without python installed

### DIFF
--- a/configure
+++ b/configure
@@ -763,20 +763,8 @@ if [ "$skype" = "1" -o "$skype" = "plugin" ]; then
 	protocols_mods="$protocol_mods skype(plugin)"
 fi
 
-if [ -z "$PYTHON" ]; then
-	PYTHON=python
-fi
-
 if [ "$doc" = "1" ]; then
-	# check this here just in case someone tries to install it in python2.4...
-	if ! $PYTHON -m xml.etree.ElementTree > /dev/null 2>&1; then
-		echo
-		echo 'ERROR: Python (>=2.5 or 3.x) is required to generate docs'
-		echo "(Use the PYTHON environment variable if it's in a weird location)"
-		exit 1
-	fi
 	echo "DOC=1" >> Makefile.settings
-	echo "PYTHON=$PYTHON" >> Makefile.settings
 fi
 
 get_version


### PR DESCRIPTION
Since help.txt is part of the tarball and python is not needed it
doesn't need to stop configure script when --doc=1 and python is not
present in the system