### PR TITLE
Twitter documentation: move commands to a chapter

### DIFF
--- a/doc/user-guide/Makefile
+++ b/doc/user-guide/Makefile
@@ -34,7 +34,7 @@ help.xml: commands.xml
 %.db.xml: %.xml docbook.xsl
 	xsltproc --xinclude --output $@ docbook.xsl $< 
 
-help.txt: $(_SRCDIR_)help.xml $(_SRCDIR_)commands.xml $(_SRCDIR_)misc.xml $(_SRCDIR_)quickstart.xml
+help.txt: $(_SRCDIR_)help.xml $(_SRCDIR_)commands.xml $(_SRCDIR_)misc.xml $(_SRCDIR_)quickstart.xml $(_SRCDIR_)twitter.xml
 	$(PYTHON) $(_SRCDIR_)genhelp.py $< $@
 
 clean: 

--- a/doc/user-guide/commands.xml
+++ b/doc/user-guide/commands.xml
@@ -890,24 +890,7 @@
 
 		<description>
 			<para>
-				With this setting enabled, you can use some commands in your Twitter channel/query. The commands are simple and not documented in too much detail:
-			</para>
-
-			<variablelist>
-				<varlistentry><term>undo #[&lt;id&gt;]</term><listitem><para>Delete your last Tweet (or one with the given ID)</para></listitem></varlistentry>
-				<varlistentry><term>rt &lt;screenname|#id&gt;</term><listitem><para>Retweet someone's last Tweet (or one with the given ID)</para></listitem></varlistentry>
-				<varlistentry><term>reply &lt;screenname|#id&gt;</term><listitem><para>Reply to a Tweet (with a reply-to reference)</para></listitem></varlistentry>
-				<varlistentry><term>rawreply &lt;screenname|#id&gt;</term><listitem><para>Reply to a Tweet (with no reply-to reference)</para></listitem></varlistentry>
-				<varlistentry><term>report &lt;screenname|#id&gt;</term><listitem><para>Report the given user (or the user who posted the tweet with the given ID) for sending spam. This will also block them.</para></listitem></varlistentry>
-				<varlistentry><term>follow &lt;screenname&gt;</term><listitem><para>Start following a person</para></listitem></varlistentry>
-				<varlistentry><term>unfollow &lt;screenname&gt;</term><listitem><para>Stop following a person</para></listitem></varlistentry>
-				<varlistentry><term>favourite &lt;screenname|#id&gt;</term><listitem><para>Favo<emphasis>u</emphasis>rite the given user's most recent tweet, or the given tweet ID.</para></listitem></varlistentry>
-				<varlistentry><term>post &lt;message&gt;</term><listitem><para>Post a tweet</para></listitem></varlistentry>
-				<varlistentry><term>url &lt;screenname|#id&gt;</term><listitem><para>Show URL for a tweet to open it in a browser (and see context)</para></listitem></varlistentry>
-			</variablelist>
-
-			<para>
-				Anything that doesn't look like a command will be treated as a tweet. Watch out for typos, or to avoid this behaviour, you can set this setting to <emphasis>strict</emphasis>, which causes the <emphasis>post</emphasis> command to become mandatory for posting a tweet.
+				With this setting enabled, you can use some commands in your Twitter channel/query. See <emphasis>help twitter</emphasis> for the list of extra commands available.
 			</para>
 		</description>
 	</bitlbee-setting>

--- a/doc/user-guide/help.xml
+++ b/doc/user-guide/help.xml
@@ -59,6 +59,7 @@ You can read more about them with <emphasis>help &lt;subject&gt;</emphasis>
 
 <xi:include href="quickstart.xml"/>
 <xi:include href="commands.xml"/>
+<xi:include href="twitter.xml"/>
 <xi:include href="misc.xml"/>
 
 </book>

--- a/doc/user-guide/twitter.xml
+++ b/doc/user-guide/twitter.xml
@@ -1,0 +1,28 @@
+<chapter id="twitter">
+<title>Twitter</title>
+
+<para>
+Twitter allows you to use a set of commands in the Twitter channel/query. See <emphasis>help set commands</emphasis>.
+</para>
+
+<para>
+Anything that doesn't look like a command will be treated as a new message. Watch out for typos, or to avoid this behaviour, set the <emphasis>commands</emphasis> setting to <emphasis>strict</emphasis>, which causes the <emphasis>post</emphasis> command to become mandatory for posting. See <emphasis>help set commands</emphasis>.
+</para>
+
+<para>
+Here is a short description of the commands available:
+<variablelist>
+<varlistentry><term>undo [&lt;#id&gt;]</term><listitem><para>Delete your last message (or one with the given ID)</para></listitem></varlistentry>
+<varlistentry><term>rt &lt;screenname|#id&gt;</term><listitem><para>Retweet someone's last message (or one with the given ID)</para></listitem></varlistentry>
+<varlistentry><term>reply &lt;screenname|#id&gt;</term><listitem><para>Reply to a message (with a reply-to reference)</para></listitem></varlistentry>
+<varlistentry><term>rawreply &lt;screenname|#id&gt;</term><listitem><para>Reply to a message (with no reply-to reference)</para></listitem></varlistentry>
+<varlistentry><term>report &lt;screenname|#id&gt;</term><listitem><para>Report the given user (or the user who posted the message with the given ID) for sending spam. This will also block them.</para></listitem></varlistentry>
+<varlistentry><term>follow &lt;screenname&gt;</term><listitem><para>Start following a person</para></listitem></varlistentry>
+<varlistentry><term>unfollow &lt;screenname&gt;</term><listitem><para>Stop following a person</para></listitem></varlistentry>
+<varlistentry><term>favourite &lt;screenname|#id&gt;</term><listitem><para>Favo<emphasis>u</emphasis>rite the given user's most recent message, or the given ID.</para></listitem></varlistentry>
+<varlistentry><term>post &lt;message&gt;</term><listitem><para>Post a message</para></listitem></varlistentry>
+<varlistentry><term>url &lt;screenname|#id&gt;</term><listitem><para>Show URL for a message to open it in a browser (and see context)</para></listitem></varlistentry>
+</variablelist>
+</para>
+
+</chapter>

--- a/doc/user-guide/user-guide.xml
+++ b/doc/user-guide/user-guide.xml
@@ -36,6 +36,7 @@
   <xi:include href="Support.xml"/>
   <xi:include href="quickstart.xml"/>
   <xi:include href="commands.xml"/>
+  <xi:include href="twitter.xml"/>
   <xi:include href="misc.xml"/>
 
 </book>


### PR DESCRIPTION
The Twitter commands are now documented in their own chapter
accessed by `help twitter` instead of being hidden in `help set
commands`.

This is a cherry pick from one of commits in PR #104.