### PR TITLE
Add a hash table to speed up bee_user_by_handle()

### DIFF
--- a/lib/misc.c
+++ b/lib/misc.c
@@ -773,3 +773,22 @@ char *str_pad_and_truncate(const char *string, long char_len, const char *ellips
 		return g_strdup(string);
 	}
 }
+
+/* copied from irssi's misc.c, by timo sirainen */
+int b_istr_equal(gconstpointer v, gconstpointer v2)
+{
+	return g_ascii_strcasecmp((const char *) v, (const char *) v2) == 0;
+}
+
+/* copied from irssi's misc.c, by lemonboy */
+guint b_istr_hash(gconstpointer v)
+{
+	const signed char *p;
+	guint32 h = 5381;
+
+	for (p = v; *p != '\0'; p++) {
+		h = (h << 5) + h + g_ascii_toupper(*p);
+	}
+
+	return h;
+}

--- a/lib/misc.h
+++ b/lib/misc.h
@@ -150,4 +150,7 @@ G_MODULE_EXPORT gboolean parse_int64(char *string, int base, guint64 *number);
 G_MODULE_EXPORT char *str_reject_chars(char *string, const char *reject, char replacement);
 G_MODULE_EXPORT char *str_pad_and_truncate(const char *string, long char_len, const char *ellipsis);
 
+G_MODULE_EXPORT int b_istr_equal(gconstpointer v, gconstpointer v2);
+G_MODULE_EXPORT guint b_istr_hash(gconstpointer v);
+
 #endif

--- a/protocols/nogaim.h
+++ b/protocols/nogaim.h
@@ -96,6 +96,7 @@ struct im_connection {
 
 	GSList *groupchats;
 	GSList *chatlist;
+	GHashTable *bee_users;
 };
 
 struct groupchat {


### PR DESCRIPTION
This maintains a hash table next to the linked list, which results in
negligible additional memory usage (~300kb for 10k users) but allows
instant lookups.

This was a big problem with discord, which has huge user lists and joins
everyone to every channel. In my test, the GUILD_SYNC event for 10k-50k
user lists is now approximately 5 times faster.

This hash table based code is only used if handle_cmp is either
exact or case-insensitive string comparison (g_ascii_strcasecmp or
strcmp/g_strcmp0).

The old function that goes through the bee->users linked list is now
called bee_user_by_handle_slow() and used for protocols with unusual
handle_cmp functions - skimming through the code, just oscar.
May revisit this if it happens to more meaningful protocols.

The case-insensitive hashtable functions are copied from irssi, which is
also GPLv2. I renamed them from g_ to b_ (g_istr_equal to b_istr_equal)

------

Putting this here for review if anyone wants to look at it, but i'm fairly confident about this one. Can't say the same about the other. I still haven't tested prpls other than discord.

```
23:43 < dx> discord - event GUILD_SYNC time: 17.513402
23:43 < dx> discord - event GUILD_SYNC time: 4.400078
23:43 < dx> before/after
23:48 < EionRobb> memory usage before and after?
23:48 < dx> haven't checked yet, but that was inside callgrind
[...]
23:58 < dx> 50k members, outside callgrind, before: 152.483041, after: 35.220947
[...]
00:12 < dx> 50k users, outside callgrind, -O2, before: 135.935320
00:13 < dx> after: 28.636779
```

Callgraph before:

![in1u9](https://user-images.githubusercontent.com/94108/42201552-c7a08220-7e6e-11e8-893f-10c74da2cfd6.png)

Callgraph after:

![fnvx3](https://user-images.githubusercontent.com/94108/42201562-d28e48b6-7e6e-11e8-8370-99a76da517bf.png)

This callgraph leads to the other optimization, next PR 