### PR TITLE
Stop using the irc->users linked list, use the hash table instead

### DIFF
--- a/irc.h
+++ b/irc.h
@@ -101,7 +101,8 @@ typedef struct irc {
 	struct query *queries;
 	GSList *file_transfers;
 
-	GSList *users, *channels;
+	GSList *users G_GNUC_DEPRECATED;
+	GSList *channels;
 	struct irc_channel *default_channel;
 	GHashTable *nick_user_hash;
 	GHashTable *watches; /* See irc_cmd_watch() */

--- a/irc_commands.c
+++ b/irc_commands.c
@@ -448,7 +448,9 @@ static void irc_cmd_who(irc_t *irc, char **cmd)
 	irc_user_t *iu;
 
 	if (!channel || *channel == '0' || *channel == '*' || !*channel) {
-		irc_send_who(irc, irc->users, "**");
+		GList *all_users = g_hash_table_get_values(irc->nick_user_hash);
+		irc_send_who(irc, (GSList *) all_users, "**");
+		g_list_free(all_users);
 	} else if ((ic = irc_channel_by_name(irc, channel))) {
 		irc_send_who(irc, ic->users, channel);
 	} else if ((iu = irc_user_by_name(irc, channel))) {

--- a/irc_im.c
+++ b/irc_im.c
@@ -180,10 +180,14 @@ void bee_irc_channel_update(irc_t *irc, irc_channel_t *ic, irc_user_t *iu)
 		return;
 	}
 	if (iu == NULL) {
-		for (l = irc->users; l; l = l->next) {
-			iu = l->data;
+		GHashTableIter iter;
+		gpointer itervalue;
+		g_hash_table_iter_init(&iter, irc->nick_user_hash);
+
+		while (g_hash_table_iter_next(&iter, NULL, &itervalue)) {
+			iu = itervalue;
 			if (iu->bu) {
-				bee_irc_channel_update(irc, ic, l->data);
+				bee_irc_channel_update(irc, ic, iu);
 			}
 		}
 		return;

--- a/irc_user.c
+++ b/irc_user.c
@@ -36,11 +36,7 @@ irc_user_t *irc_user_new(irc_t *irc, const char *nick)
 
 	iu->key = g_strdup(nick);
 	nick_lc(irc, iu->key);
-	/* Using the hash table for speed and irc->users for easy iteration
-	   through the list (since the GLib API doesn't have anything sane
-	   for that.) */
 	g_hash_table_insert(irc->nick_user_hash, iu->key, iu);
-	irc->users = g_slist_insert_sorted(irc->users, iu, irc_user_cmp);
 
 	return iu;
 }
@@ -86,7 +82,6 @@ int irc_user_free(irc_t *irc, irc_user_t *iu)
 	}
 	irc_user_quit(iu, msg);
 
-	irc->users = g_slist_remove(irc->users, iu);
 	g_hash_table_remove(irc->nick_user_hash, iu->key);
 
 	g_free(iu->nick);
@@ -147,7 +142,6 @@ int irc_user_set_nick(irc_user_t *iu, const char *new)
 		}
 	}
 
-	irc->users = g_slist_remove(irc->users, iu);
 	g_hash_table_remove(irc->nick_user_hash, iu->key);
 
 	if (iu->nick == iu->user) {
@@ -174,7 +168,6 @@ int irc_user_set_nick(irc_user_t *iu, const char *new)
 	g_free(iu->key);
 	iu->key = g_strdup(key);
 	g_hash_table_insert(irc->nick_user_hash, iu->key, iu);
-	irc->users = g_slist_insert_sorted(irc->users, iu, irc_user_cmp);
 
 	if (iu == irc->user) {
 		ipc_to_master_str("NICK :%s\r\n", new);


### PR DESCRIPTION
~~[INCOMPLETE! Some things are half-assed. But it works.]~~

irc_user_new() mentions that the reason this list is kept is for easy
iteration. Luckily, this is the future, and GHashTableIter exists now.

The main point of this is to get rid of the g_slist_insert_sorted() in
irc_user_set_nick() which is a particularly slow part of loading large
user lists, and scales poorly

In a test with discord, the GUILD_SYNC event is now 4 times faster, on
top of the improvements of the other bee_user hash tables patch.
Combining both patches it went from 136 to 6 seconds for 50k members.

-----

Callgraph that led to this:

![sari4](https://user-images.githubusercontent.com/94108/42202513-12e5ee5c-7e72-11e8-9e40-8c283307986c.png)

Callgraph after:

![vbkh4](https://user-images.githubusercontent.com/94108/42202528-219d1218-7e72-11e8-8b20-637876c7d04e.png)

That stuff is handled at https://github.com/sm00th/bitlbee-discord/pull/165