### PR TITLE
show correct nick when `rename -del` is used

### DIFF
--- a/root_commands.c
+++ b/root_commands.c
@@ -818,7 +818,7 @@ static void cmd_rename(irc_t *irc, char **cmd)
 	iu = irc_user_by_name(irc, cmd[del ? 2 : 1]);
 
 	if (iu == NULL) {
-		irc_rootmsg(irc, "Nick `%s' does not exist", cmd[1]);
+		irc_rootmsg(irc, "Nick `%s' does not exist", cmd[del ? 2 : 1]);
 	} else if (del) {
 		if (iu->bu) {
 			bee_irc_user_nick_reset(iu);


### PR DESCRIPTION
I thought `rename -del` was broken until I looked at the source and realised it was just trying to tell me that the nick I was deleting didn't exist. Fixes this error message:

    <root> Nick `-del' does not exist

Tangential, but `help rename` suggesting `rename -del <oldnick>` is a bit misleading and implies that the original handle should be used with the command, instead of the current/new/renamed nick. Would just `<nick>` be more appropriate there maybe?

EDIT: aaand I just realised this is targeting the wrong branch. can I change that ;-;