### PR TITLE
rename -del help clarification

### DIFF
--- a/doc/user-guide/commands.xml
+++ b/doc/user-guide/commands.xml
@@ -1765,7 +1765,7 @@
 	<bitlbee-command name="rename">
 		<short-description>Rename (renick) a buddy</short-description>
 		<syntax>rename &lt;oldnick&gt; &lt;newnick&gt;</syntax>
-		<syntax>rename -del &lt;oldnick&gt;</syntax>
+		<syntax>rename -del &lt;nick&gt;</syntax>
 
 		<description>
 			<para>


### PR DESCRIPTION
In context next to `help rename <oldnick> <newnick>`, instructing users to `rename -del <oldnick>` indicates that the original handle should be used instead of the user's current nick. This is not the case, so I think this change makes sense to help clarify that?

This could also be `rename -del <newnick>` instead to indicate that it's for deleting nicks that have already been renamed using the aforementioned command? Either way works for me.