### PR TITLE
Use GString for irc->sendbuffer (simpler and faster)

### DIFF
--- a/irc.h
+++ b/irc.h
@@ -84,7 +84,7 @@ typedef struct irc {
 	irc_status_t status;
 	double last_pong;
 	int pinging;
-	char *sendbuffer;
+	GString *sendbuffer;
 	char *readbuffer;
 	GIConv iconv, oconv;
 

--- a/unix.c
+++ b/unix.c
@@ -372,7 +372,7 @@ static void sighandler_crash(int signal)
 		irc_t *irc = l->data;
 		sock_make_blocking(irc->fd);
 		if (irc->sendbuffer) {
-			(void) write(irc->fd, irc->sendbuffer, strlen(irc->sendbuffer));
+			(void) write(irc->fd, irc->sendbuffer->str, irc->sendbuffer->len);
 		}
 		(void) write(irc->fd, message, sizeof(message) - 1);
 	}


### PR DESCRIPTION
The old code managed growing the buffer manually and called strlen()
very often. GString has a length field and the logic to grow the buffer
is none of our business. Probably smarter, too.

This takes a "blist all" of 14k users from 8.2 to 1.3 seconds.

----

Fairly confident about this one but throwing it here first to be safe.

Unsure about:

* `g_string_erase(irc->sendbuffer, 0, sent_bytes);` actually doing the same thing as `g_strdup(irc->sendbuffer + sent_bytes);` (i guess, but should prove it with code)
* API/ABI stuff. This changes a field in irc.h with another with the same size so the ABI side looks good imo. The API side, uh, can I just say plugins shouldn't be touching this?
