### PR TITLE
SSL: correctly handle hostnames starting with a digit when SNI is needed.

### DIFF
--- a/lib/ssl_gnutls.c
+++ b/lib/ssl_gnutls.c
@@ -322,7 +322,7 @@ static gboolean ssl_connected(gpointer data, gint source, b_input_condition cond
 #endif
 	gnutls_set_default_priority(conn->session);
 	gnutls_credentials_set(conn->session, GNUTLS_CRD_CERTIFICATE, xcred);
-	if (conn->hostname && !g_ascii_isdigit(conn->hostname[0])) {
+	if (conn->hostname && !g_hostname_is_ip_address(conn->hostname)) {
 		gnutls_server_name_set(conn->session, GNUTLS_NAME_DNS,
 		                       conn->hostname, strlen(conn->hostname));
 	}

--- a/lib/ssl_openssl.c
+++ b/lib/ssl_openssl.c
@@ -166,7 +166,7 @@ static gboolean ssl_connected(gpointer data, gint source, b_input_condition cond
 	sock_make_nonblocking(conn->fd);
 	SSL_set_fd(conn->ssl, conn->fd);
 
-	if (conn->hostname && !g_ascii_isdigit(conn->hostname[0])) {
+	if (conn->hostname && !g_hostname_is_ip_address(conn->hostname)) {
 		SSL_set_tlsext_host_name(conn->ssl, conn->hostname);
 	}
 


### PR DESCRIPTION
I noticed that I was unable to connect to a host with bitlbee.
Tracking it down, I found that the problem was that the host needed SNI
but bitlbee wasn't trying to use it.  The hostname started with a digit,
so bitlbee was assuming that it was an IP address.