### PR TITLE
Depend on newer debhelper (>= 9.20160709) rather than dh-systemd.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+bitlbee (3.6-2) UNRELEASED; urgency=medium
+
+  * Depend on newer debhelper (>= 9.20160709) rather than dh-systemd.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Thu, 21 Mar 2019 00:10:27 +0000
+
 bitlbee (3.6-1) unstable; urgency=medium
 
   [ dequis ]

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Wilmer van der Gaast <wilmer@gaast.net>
 Uploaders: Jelmer Vernooĳ <jelmer@debian.org>
 Standards-Version: 3.9.8
-Build-Depends: libglib2.0-dev (>= 2.4), libevent-dev, libgnutls28-dev | libgnutls-dev | gnutls-dev, po-debconf, libpurple-dev, libotr5-dev, debhelper (>= 10~), dh-systemd (>= 1.5), python
+Build-Depends: libglib2.0-dev (>= 2.4), libevent-dev, libgnutls28-dev | libgnutls-dev | gnutls-dev, po-debconf, libpurple-dev, libotr5-dev, debhelper (>= 10~), python
 Homepage: http://www.bitlbee.org/
 Vcs-Git: https://github.com/bitlbee/bitlbee
 Vcs-Browser: https://github.com/bitlbee/bitlbee


### PR DESCRIPTION
Depend on newer debhelper (>= 9.20160709) rather than dh-systemd.
This merge proposal was created automatically by the Janitor bot
(https://janitor.debian.net/).

You can follow up to this merge proposal as you normally would.

Build and test logs for this branch can be found at
https://janitor.debian.net/pkg/bitlbee/logs/146bac9c-f6fa-4978-a2b0-952d70152ce7.
