### PR TITLE
purple: add defer_joins, use_matrix_alias and name_with_tag options

### DIFF
--- a/bitlbee.h
+++ b/bitlbee.h
@@ -121,7 +121,7 @@ extern "C" {
 #define CONTROL_TOPIC "Welcome to the control channel. Type \2help\2 for help information."
 #define IRCD_INFO PACKAGE " <http://www.bitlbee.org/>"
 
-#define MAX_NICK_LENGTH 24
+#define MAX_NICK_LENGTH 80
 
 #define HELP_FILE VARDIR "help.txt"
 #define CONF_FILE_DEF ETCDIR "bitlbee.conf"

--- a/protocols/purple/purple.c
+++ b/protocols/purple/purple.c
@@ -284,6 +284,15 @@ static void purple_init(account_t *acc)
 	s = set_add(&acc->set, "display_name", NULL, set_eval_display_name, acc);
 	s->flags |= ACC_SET_ONLINE_ONLY;
 
+	s = set_add(&acc->set, "defer_joins", "false", set_eval_bool, acc);
+	s->flags |= ACC_SET_OFFLINE_ONLY;
+
+	s = set_add(&acc->set, "use_matrix_alias", "false", set_eval_bool, acc);
+	s->flags |= ACC_SET_OFFLINE_ONLY;
+
+	s = set_add(&acc->set, "name_with_tag", "false", set_eval_bool, acc);
+	s->flags |= ACC_SET_OFFLINE_ONLY;
+
 	if (pi->options & OPT_PROTO_MAIL_CHECK) {
 		s = set_add(&acc->set, "mail_notifications", "false", set_eval_bool, acc);
 		s->flags |= ACC_SET_OFFLINE_ONLY;
@@ -1107,6 +1116,24 @@ static PurpleBlistUiOps bee_blist_uiops =
 	prplcb_blist_remove,       /* remove */
 };
 
+void purple_hint_chat_names(struct groupchat *gc, PurpleConversation *conv) {
+	char *hint = NULL;
+	if (conv->title != NULL) {
+		hint = conv->title;
+	}
+	if (set_getbool(&(gc->ic->acc->set), "use_matrix_alias") && purple_conversation_get_data(conv, "matrix_alias") != NULL) {
+		hint = (char *) purple_conversation_get_data(conv, "matrix_alias");
+	}
+	if (set_getbool(&(gc->ic->acc->set), "name_with_tag")) {
+		char tagged_name[128];
+		char *tag = set_getstr(&(gc->ic->acc->set), "tag");
+		g_snprintf(tagged_name, sizeof(tagged_name), "%s-%s", tag, hint);
+		imcb_chat_name_hint(gc, tagged_name);
+	}
+	else {
+		imcb_chat_name_hint(gc, conv->title);
+	}
+}
 void prplcb_conv_new(PurpleConversation *conv)
 {
 	if (conv->type == PURPLE_CONV_TYPE_CHAT) {
@@ -1117,9 +1144,7 @@ void prplcb_conv_new(PurpleConversation *conv)
 
 		if (!gc) {
 			gc = imcb_chat_new(ic, conv->name);
-			if (conv->title != NULL) {
-				imcb_chat_name_hint(gc, conv->title);
-			}
+			purple_hint_chat_names(gc, conv);
 		}
 
 		/* don't set the topic if it's just the name */
@@ -1133,7 +1158,12 @@ void prplcb_conv_new(PurpleConversation *conv)
 		/* libpurple brokenness: Whatever. Show that we join right away,
 		   there's no clear "This is you!" signaling in _add_users so
 		   don't even try. */
-		imcb_chat_add_buddy(gc, gc->ic->acc->user);
+		if (!set_getbool(&(ic->acc->set), "defer_joins")) {
+			imcb_chat_add_buddy(gc, gc->ic->acc->user);
+		}
+		else {
+			imcb_log(gc->ic, "Deferring join to %s", conv->name);
+		}
 	}
 }
 
@@ -1154,6 +1184,10 @@ void prplcb_conv_add_users(PurpleConversation *conv, GList *cbuddies, gboolean n
 
 		imcb_chat_add_buddy(gc, pcb->name);
 	}
+	purple_hint_chat_names(gc, conv);
+	if (!gc->joined) {
+		imcb_chat_add_buddy(gc, gc->ic->acc->user);
+	}
 }
 
 void prplcb_conv_del_users(PurpleConversation *conv, GList *cbuddies)
@@ -1171,7 +1205,7 @@ static void handle_conv_msg(PurpleConversation *conv, const char *who, const cha
 {
 	struct im_connection *ic = purple_ic_by_pa(conv->account);
 	struct groupchat *gc = conv->ui_data;
-	char *message = g_strdup(message_);
+	char *message = purple_unescape_html(message_);
 	PurpleBuddy *buddy;
 
 	buddy = purple_find_buddy(conv->account, who);


### PR DESCRIPTION
(Most of these changes are aimed at making matrix not a pain to use)
- The `defer_joins` option on prpl accounts waits for users to be added
  to a prpl conversation before adding the bitlbee user, in the hope
  of being able to get some chat name/alias metadata before doing so.
- (To that end, the name hint for rooms is now updated when users are
  added.)
- The `name_with_tag` options prefixes the account tag to the name hint
  for prpl accounts, in order to namespace prpl channels somewhat.
- The `use_matrix_alias` option is specialized for the purple-matrix
  plugin, and makes the name hint use the `matrix_alias` data item
  of the prpl conversation, instead of the title.
- Also, `MAX_NICK_LENGTH` was increased to 80 (because matrix room names are long).