### PR TITLE
Depend on newer debhelper (>= 9.20160709) rather than dh-systemd.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+bitlbee (3.6-2) UNRELEASED; urgency=medium
+
+  * Depend on newer debhelper (>= 9.20160709) rather than dh-systemd.
+
+ -- Jelmer Vernooĳ <jelmer@debian.org>  Fri, 19 Apr 2019 12:31:53 +0000
+
 bitlbee (3.6-1) unstable; urgency=medium
 
   [ dequis ]

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Wilmer van der Gaast <wilmer@gaast.net>
 Uploaders: Jelmer Vernooĳ <jelmer@debian.org>
 Standards-Version: 3.9.8
-Build-Depends: libglib2.0-dev (>= 2.4), libevent-dev, libgnutls28-dev | libgnutls-dev | gnutls-dev, po-debconf, libpurple-dev, libotr5-dev, debhelper (>= 10~), dh-systemd (>= 1.5), python
+Build-Depends: libglib2.0-dev (>= 2.4), libevent-dev, libgnutls28-dev | libgnutls-dev | gnutls-dev, po-debconf, libpurple-dev, libotr5-dev, debhelper (>= 10~), python
 Homepage: http://www.bitlbee.org/
 Vcs-Git: https://github.com/bitlbee/bitlbee
 Vcs-Browser: https://github.com/bitlbee/bitlbee


### PR DESCRIPTION
Depend on newer debhelper (>= 9.20160709) rather than dh-systemd.