### PR TITLE
conf: support AccountStorage as well as Account_Storage

### DIFF
--- a/conf.c
+++ b/conf.c
@@ -276,10 +276,12 @@ static int conf_loadini(conf_t *conf, char *file)
 			} else if (g_strcasecmp(ini->key, "motdfile") == 0) {
 				g_free(conf->motdfile);
 				conf->motdfile = g_strdup(ini->value);
-			} else if (g_strcasecmp(ini->key, "account_storage") == 0) {
+			} else if (g_strcasecmp(ini->key, "accountstorage") == 0 ||
+				   g_strcasecmp(ini->key, "account_storage") == 0) {
 				g_free(conf->primary_storage);
 				conf->primary_storage = g_strdup(ini->value);
-			} else if (g_strcasecmp(ini->key, "account_storage_migrate") == 0) {
+			} else if (g_strcasecmp(ini->key, "accountstoragemigrate") == 0 ||
+				   g_strcasecmp(ini->key, "account_storage_migrate") == 0) {
 				g_strfreev(conf->migrate_storage);
 				conf->migrate_storage = g_strsplit_set(ini->value, " \t,;", -1);
 			} else if (g_strcasecmp(ini->key, "pinginterval") == 0) {


### PR DESCRIPTION
These variables added way back in b73ac9c3 ("Add support for 'primary'
and 'migrate' account storages. [...]", 2005-12-14). I think that
these have never been used by anyone, I think Dennis's out-of-tree
MySQL backend is the only storage backend anyone bothered to write.

That backend uses "AccountStorage" in the config, not
"Account_Storage". Let's support that, we could just change this over,
but *maybe* someone uses it out of tree, and supporting their config
in that case is easy.

I'm forward-porting https://github.com/bitlbee/bitlbee/pull/67 there's
production code that uses the CamelCase variant, and it would be handy
if it worked as-is without needing to fiddle with the config.

Signed-off-by: Ævar Arnfjörð Bjarmason <avarab@gmail.com>