### PR TITLE
Don't make early warnings go nowhere

### DIFF
--- a/unix.c
+++ b/unix.c
@@ -79,6 +79,9 @@ int main(int argc, char *argv[])
 	}
 
 	log_init();
+	/* Catch early errors */
+	log_link(LOGLVL_ERROR, LOGOUTPUT_CONSOLE);
+	log_link(LOGLVL_WARNING, LOGOUTPUT_CONSOLE);
 
 	global.conf_file = g_strdup(CONF_FILE_DEF);
 	global.conf = conf_load(argc, argv);


### PR DESCRIPTION
between log_init and the existing log_link calls, all errors and
warnings would go nowhere. Let's show them on the console.

Signed-off-by: Ævar Arnfjörð Bjarmason <avarab@gmail.com>