### PR TITLE
Centralize password handling functions

### DIFF
--- a/bitlbee.h
+++ b/bitlbee.h
@@ -146,6 +146,7 @@ extern "C" {
 #include "sock.h"
 #include "misc.h"
 #include "proxy.h"
+#include "password.h"
 
 typedef struct global {
 	/* In forked mode, child processes store the fd of the IPC socket here. */

--- a/irc_commands.c
+++ b/irc_commands.c
@@ -44,14 +44,20 @@ static void irc_cmd_pass(irc_t *irc, char **cmd)
 	}
 	/* Handling in pre-logged-in state, first see if this server is
 	   password-protected: */
-	else if (global.conf->auth_pass &&
-	         (strncmp(global.conf->auth_pass, "md5:", 4) == 0 ?
-	          md5_verify_password(cmd[1], global.conf->auth_pass + 4) == 0 :
-	          strcmp(cmd[1], global.conf->auth_pass) == 0)) {
-		irc->status |= USTATUS_AUTHORIZED;
-		irc_check_login(irc);
-	} else if (global.conf->auth_pass) {
-		irc_send_num(irc, 464, ":Incorrect password");
+	else if (global.conf->auth_pass) {
+		int password_ok = 0;
+		if (strncmp(global.conf->auth_pass, "md5:", 4) == 0) {
+			password_ok = password_verify(cmd[1], global.conf->auth_pass + 4) == 0;
+		}
+		else {
+			password_ok = strcmp(cmd[1], global.conf->auth_pass) == 0;
+		}
+		if (password_ok) {
+			irc->status |= USTATUS_AUTHORIZED;
+			irc_check_login(irc);
+		} else {
+			irc_send_num(irc, 464, ":Incorrect password");
+		}
 	} else {
 		/* Remember the password and try to identify after USER/NICK. */
 		irc_setpass(irc, cmd[1]);
@@ -540,15 +546,21 @@ static void irc_cmd_oper_hack(irc_t *irc, char **cmd);
 
 static void irc_cmd_oper(irc_t *irc, char **cmd)
 {
+	int password_ok = 0;
 	/* Very non-standard evil but useful/secure hack, see below. */
 	if (irc->status & OPER_HACK_ANY) {
 		return irc_cmd_oper_hack(irc, cmd);
 	}
 
-	if (global.conf->oper_pass &&
-	    (strncmp(global.conf->oper_pass, "md5:", 4) == 0 ?
-	     md5_verify_password(cmd[2], global.conf->oper_pass + 4) == 0 :
-	     strcmp(cmd[2], global.conf->oper_pass) == 0)) {
+	if (global.conf->oper_pass) {
+		if (strncmp(global.conf->oper_pass, "md5:", 4) == 0) {
+			password_ok = password_verify(cmd[1], global.conf->oper_pass + 4) == 0;
+		}
+		else {
+			password_ok = strcmp(cmd[1], global.conf->oper_pass) == 0;
+		}
+	}
+	if(password_ok) {
 		irc_umode_set(irc, "+o", 1);
 		irc_send_num(irc, 381, ":Password accepted");
 	} else {

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -12,7 +12,7 @@ _SRCDIR_ := $(_SRCDIR_)lib/
 endif
 
 # [SH] Program variables
-objects = arc.o base64.o canohost.o $(EVENT_HANDLER) ftutil.o http_client.o ini.o json.o json_util.o md5.o misc.o oauth.o oauth2.o proxy.o sha1.o $(SSL_CLIENT) url.o xmltree.o ns_parse.o
+objects = arc.o base64.o canohost.o $(EVENT_HANDLER) ftutil.o http_client.o ini.o json.o json_util.o md5.o misc.o oauth.o oauth2.o proxy.o sha1.o $(SSL_CLIENT) url.o xmltree.o ns_parse.o password.o
 
 LFLAGS += -r
 

--- a/lib/misc.c
+++ b/lib/misc.c
@@ -561,40 +561,6 @@ gboolean ssl_sockerr_again(void *ssl)
 	}
 }
 
-/* Returns values: -1 == Failure (base64-decoded to something unexpected)
-                    0 == Okay
-                    1 == Password doesn't match the hash. */
-int md5_verify_password(char *password, char *hash)
-{
-	md5_byte_t *pass_dec = NULL;
-	md5_byte_t pass_md5[16];
-	md5_state_t md5_state;
-	int ret = -1, i;
-
-	if (base64_decode(hash, &pass_dec) == 21) {
-		md5_init(&md5_state);
-		md5_append(&md5_state, (md5_byte_t *) password, strlen(password));
-		md5_append(&md5_state, (md5_byte_t *) pass_dec + 16, 5);  /* Hmmm, salt! */
-		md5_finish(&md5_state, pass_md5);
-
-		for (i = 0; i < 16; i++) {
-			if (pass_dec[i] != pass_md5[i]) {
-				ret = 1;
-				break;
-			}
-		}
-
-		/* If we reached the end of the loop, it was a match! */
-		if (i == 16) {
-			ret = 0;
-		}
-	}
-
-	g_free(pass_dec);
-
-	return ret;
-}
-
 /* Split commands (root-style, *not* IRC-style). Handles "quoting of"
    white\ space in 'various ways'. Returns a NULL-terminated static
    char** so watch out with nested use! Definitely not thread-safe. */

--- a/lib/misc.h
+++ b/lib/misc.h
@@ -142,7 +142,6 @@ G_MODULE_EXPORT void srv_free(struct ns_srv_reply **srv);
 
 G_MODULE_EXPORT char *word_wrap(const char *msg, int line_len);
 G_MODULE_EXPORT gboolean ssl_sockerr_again(void *ssl);
-G_MODULE_EXPORT int md5_verify_password(char *password, char *hash);
 G_MODULE_EXPORT char **split_command_parts(char *command, int limit);
 G_MODULE_EXPORT char *get_rfc822_header(const char *text, const char *header, int len);
 G_MODULE_EXPORT int truncate_utf8(char *string, int maxlen);

--- a/lib/password.c
+++ b/lib/password.c
@@ -1,0 +1,89 @@
+#define BITLBEE_CORE
+#include "bitlbee.h"
+#include "base64.h"
+#include "arc.h"
+#include "md5.h"
+
+size_t password_hash(const char *password, char **hash)
+{
+	md5_byte_t pass_md5[21];
+	md5_state_t md5_state;
+
+	/* Generate a salted md5sum of the password. Use 5 bytes for the salt
+	   (to prevent dictionary lookups of passwords) to end up with a 21-
+	   byte password hash, more convenient for base64 encoding. */
+	random_bytes(pass_md5 + 16, 5);
+	md5_init(&md5_state);
+	md5_append(&md5_state, (md5_byte_t *) password, strlen(password));
+	md5_append(&md5_state, pass_md5 + 16, 5);   /* Add the salt. */
+	md5_finish(&md5_state, pass_md5);
+
+	/* Save the hash in base64-encoded form. */
+	*hash = base64_encode(pass_md5, 21);
+	return strlen(*hash);
+}
+
+/* Returns values: -1 == Failure (base64-decoded to something unexpected)
+                    0 == Okay
+                    1 == Password doesn't match the hash. */
+int password_verify(const char *password, const char *hash)
+{
+	md5_byte_t *pass_dec = NULL;
+	md5_byte_t pass_md5[16];
+	md5_state_t md5_state;
+	int ret = -1, i;
+
+	if (base64_decode(hash, &pass_dec) == 21) {
+		md5_init(&md5_state);
+		md5_append(&md5_state, (md5_byte_t *) password, strlen(password));
+		md5_append(&md5_state, (md5_byte_t *) pass_dec + 16, 5);  /* Hmmm, salt! */
+		md5_finish(&md5_state, pass_md5);
+
+		for (i = 0; i < 16; i++) {
+			if (pass_dec[i] != pass_md5[i]) {
+				ret = 1;
+				break;
+			}
+		}
+
+		/* If we reached the end of the loop, it was a match! */
+		if (i == 16) {
+			ret = 0;
+		}
+	}
+
+	g_free(pass_dec);
+
+	return ret;
+}
+
+size_t password_encode(const char *password, char **encoded)
+{
+	*encoded = base64_encode((unsigned char *)password, strlen(password));
+	return *encoded ? -1 : strlen(*encoded);
+}
+
+size_t password_decode(const char *encoded, char **password)
+{
+	return base64_decode(encoded, (unsigned char **)password);
+}
+
+size_t password_encrypt(const char *password, const char *encryption_key, char **crypt)
+{
+	unsigned char *encrypted;
+	size_t pass_len = arc_encode((char *)password, strlen(password), &encrypted, (char *)encryption_key, 12);
+	*crypt = base64_encode(encrypted, pass_len);
+	g_free(encrypted);
+	return strlen(*crypt);
+}
+
+size_t password_decrypt(const char *encrypted, const char *encryption_key, char **password)
+{
+	unsigned char *decoded;
+	size_t pass_len = base64_decode(encrypted, &decoded);
+	if (pass_len) {
+		pass_len = arc_decode(decoded, pass_len, password, encryption_key);
+		g_free(decoded);
+	}
+	return pass_len;
+}

--- a/lib/password.h
+++ b/lib/password.h
@@ -1,0 +1,11 @@
+#ifndef _PASSWORD_H
+#define _PASSWORD_H
+
+size_t password_hash(const char *password, char **hash);
+int password_verify(const char *password, const char *hash);
+size_t password_encode(const char *password, char **encoded);
+size_t password_decode(const char *encoded, char **password);
+size_t password_encrypt(const char *password, const char *encryption_key, char **crypt);
+size_t password_decrypt(const char *encrypted, const char *encryption_key, char **password);
+
+#endif


### PR DESCRIPTION
In preparation for the next commit and the forthcoming MySQL storage
backend, I needed to centralize all password handling. This commit
achieves a few things at once that are not easy to split up in multiple
commits while keeping every commit buildable/testable:

- One place to encode/encrypt/decode/decrypt/verify all passwords
- Less code duplication (several places did their own md5 handling)
- Reusable password encryption
- Generic function names instead of hardcoding md5/arc in the name
- Clearer and easier to extend password checking logic

Signed-off-by: Ævar Arnfjörð Bjarmason <avarab@gmail.com>