### PR TITLE
Fix compiler warning

### DIFF
--- a/lib/events.h
+++ b/lib/events.h
@@ -57,8 +57,8 @@ typedef gboolean (*b_event_handler)(gpointer data, gint fd, b_input_condition co
 #define GAIM_WRITE_COND (G_IO_OUT | G_IO_HUP | G_IO_ERR | G_IO_NVAL)
 #define GAIM_ERR_COND   (G_IO_HUP | G_IO_ERR | G_IO_NVAL)
 
-/* #define event_debug( x... ) printf( x ) */
-#define event_debug(x ...)
+/* #define event_debug( ... ) printf( __VA_ARGS__ ) */
+#define event_debug(...)
 
 /* Call this once when the program starts. It'll initialize the event handler
    library (if necessary) and then return immediately. */


### PR DESCRIPTION
Fix "ISO C does not permit named variadic macros" when compiling under -Wvariadic-macros.

[On StackOverflow](https://stackoverflow.com/questions/6750512/gcc-warning-iso-c-does-not-permit-named-variadic-macros), Matthew Slattery  says:

> This is a [GCC extension](http://gcc.gnu.org/onlinedocs/gcc-4.2.1/gcc/Variadic-Macros.html).
> [C99](http://www.open-std.org/JTC1/SC22/WG14/www/docs/n1256.pdf) does define a way of passing variable arguments to macros (see §6.10.3/12 and §6.10.3.1/2): the variable arguments are unnamed on the left-hand side of the definitions (i.e. just ...), and referenced on the right-hand side as __VA_ARGS__