### PR TITLE
g_hash_table_contains() exists since GLib >= 2.32

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ You can also use a public server (such as `im.bitlbee.org`) instead of installin
 
 If you wish to compile it yourself, ensure you have the following packages and their headers:
 
-* glib 2.16 or newer (not to be confused with glibc)
+* glib 2.32 or newer (not to be confused with glibc)
 * gnutls
 * python 2 or 3 (for the user guide)
 

--- a/configure
+++ b/configure
@@ -56,7 +56,7 @@ pie=1
 
 arch=$(uname -s)
 
-GLIB_MIN_VERSION=2.16
+GLIB_MIN_VERSION=2.32
 
 # Cygwin and Darwin don't support PIC/PIE
 case "$arch" in


### PR DESCRIPTION
Usage of `g_hash_table_contains()` was introduced by commit 5c90890.