### PR TITLE
Compare tweets by status ID as fallback for identical dates.

### DIFF
--- a/protocols/twitter/twitter_lib.c
+++ b/protocols/twitter/twitter_lib.c
@@ -131,7 +131,7 @@ static gint twitter_compare_elements(gconstpointer a, gconstpointer b)
 	} else if (a_status->created_at > b_status->created_at) {
 		return 1;
 	} else {
-		return 0;
+		return a_status->id < b_status->id ? -1 : 1;
 	}
 }
 


### PR DESCRIPTION
This fixes an issue where a thread composed using Twitter's thread interface is displayed out of order. With this change a series of statuses in a thread fetched during one poll of the timeline are correctly arranged and marked as replies to each other, rather than being in an arbitrary (often wrong) order.

As far as I can tell this doesn't have any knock-on effects from anything relying on twitter_compare_elements returning 0.