### PR TITLE
Add support for group reply using auto_populate_reply_metadata

### DIFF
--- a/doc/user-guide/twitter.xml
+++ b/doc/user-guide/twitter.xml
@@ -14,8 +14,9 @@ Here is a short description of the commands available:
 <variablelist>
 <varlistentry><term>undo [&lt;#id&gt;]</term><listitem><para>Delete your last message (or one with the given ID)</para></listitem></varlistentry>
 <varlistentry><term>rt &lt;screenname|#id&gt;</term><listitem><para>Retweet someone's last message (or one with the given ID)</para></listitem></varlistentry>
-<varlistentry><term>reply &lt;screenname|#id&gt;</term><listitem><para>Reply to a message (with a reply-to reference)</para></listitem></varlistentry>
+<varlistentry><term>reply &lt;screenname|#id&gt;</term><listitem><para>Reply to a message (with a reply-to reference, mentions only one user)</para></listitem></varlistentry>
 <varlistentry><term>rawreply &lt;screenname|#id&gt;</term><listitem><para>Reply to a message (with no reply-to reference)</para></listitem></varlistentry>
+<varlistentry><term>greply &lt;screenname|#id&gt;</term><listitem><para>Group reply to a message (with reply-to, mentions every user in the conversation)</para></listitem></varlistentry>
 <varlistentry><term>report &lt;screenname|#id&gt;</term><listitem><para>Report the given user (or the user who posted the message with the given ID) for sending spam. This will also block them.</para></listitem></varlistentry>
 <varlistentry><term>follow &lt;screenname&gt;</term><listitem><para>Start following a person</para></listitem></varlistentry>
 <varlistentry><term>unfollow &lt;screenname&gt;</term><listitem><para>Stop following a person</para></listitem></varlistentry>

--- a/protocols/twitter/twitter.c
+++ b/protocols/twitter/twitter.c
@@ -1005,7 +1005,7 @@ static void twitter_handle_command(struct im_connection *ic, char *message)
 		}
 		message = new = g_strdup_printf("%s", cmd[2]);
 		in_reply_to = id;
-                auto_populate_reply_metadata = TRUE;
+		auto_populate_reply_metadata = TRUE;
 		allow_post = TRUE;
 	} else if (g_strcasecmp(cmd[0], "rawreply") == 0 && cmd[1] && cmd[2]) {
 		id = twitter_message_id_from_command_arg(ic, cmd[1], NULL);

--- a/protocols/twitter/twitter.c
+++ b/protocols/twitter/twitter.c
@@ -917,6 +917,7 @@ static void twitter_handle_command(struct im_connection *ic, char *message)
 	guint64 in_reply_to = 0, id;
 	gboolean allow_post =
 	        g_strcasecmp(set_getstr(&ic->acc->set, "commands"), "strict") != 0;
+	gboolean auto_populate_reply_metadata = FALSE;
 	bee_user_t *bu = NULL;
 
 	cmds = g_strdup(message);
@@ -995,6 +996,17 @@ static void twitter_handle_command(struct im_connection *ic, char *message)
 		message = new = g_strdup_printf("@%s %s", bu->handle, cmd[2]);
 		in_reply_to = id;
 		allow_post = TRUE;
+	} else if (g_strcasecmp(cmd[0], "greply") == 0 && cmd[1] && cmd[2]) {
+		id = twitter_message_id_from_command_arg(ic, cmd[1], &bu);
+		if (!id || !bu) {
+			twitter_log(ic, "User `%s' does not exist or didn't "
+			            "post any statuses recently", cmd[1]);
+			goto eof;
+		}
+		message = new = g_strdup_printf("%s", cmd[2]);
+		in_reply_to = id;
+                auto_populate_reply_metadata = TRUE;
+		allow_post = TRUE;
 	} else if (g_strcasecmp(cmd[0], "rawreply") == 0 && cmd[1] && cmd[2]) {
 		id = twitter_message_id_from_command_arg(ic, cmd[1], NULL);
 		if (!id) {
@@ -1046,7 +1058,7 @@ static void twitter_handle_command(struct im_connection *ic, char *message)
 		/* If the user runs undo between this request and its response
 		   this would delete the second-last Tweet. Prevent that. */
 		td->last_status_id = 0;
-		twitter_post_status(ic, message, in_reply_to);
+		twitter_post_status(ic, message, in_reply_to, auto_populate_reply_metadata);
 	} else {
 		twitter_log(ic, "Unknown command: %s", cmd[0]);
 	}

--- a/protocols/twitter/twitter_lib.c
+++ b/protocols/twitter/twitter_lib.c
@@ -1736,10 +1736,10 @@ void twitter_post_status(struct im_connection *ic, char *msg, guint64 in_reply_t
 	twitter_http(ic, TWITTER_STATUS_UPDATE_URL, twitter_http_post, ic, 1,
 	             args, args_len);
 	if (in_reply_to_str) {
-	    g_free(in_reply_to_str);
+		g_free(in_reply_to_str);
 	}
 	if (place_id_str) {
-	    g_free(place_id_str);
+		g_free(place_id_str);
 	}
 	g_free(args);
 }

--- a/protocols/twitter/twitter_lib.c
+++ b/protocols/twitter/twitter_lib.c
@@ -1695,24 +1695,53 @@ static void twitter_http_post(struct http_request *req)
 /**
  * Function to POST a new status to twitter.
  */
-void twitter_post_status(struct im_connection *ic, char *msg, guint64 in_reply_to)
+void twitter_post_status(struct im_connection *ic, char *msg, guint64 in_reply_to, gboolean auto_populate_reply_metadata)
 {
-	char *args[4] = {
-		"status", msg,
-		"in_reply_to_status_id",
-		g_strdup_printf("%" G_GUINT64_FORMAT, in_reply_to)
-	};
+	size_t args_len = 0;
+	char * in_reply_to_str = NULL;
+	char * place_id_str = NULL;
+	gboolean in_korea = (set_getbool(&ic->acc->set, "in_korea") && !in_reply_to);
 
-	if (set_getbool(&ic->acc->set, "in_korea") && !in_reply_to) {
-		g_free(args[3]);
-		args[2] = "place_id";
-		args[3] = g_strdup("c999e6a453e9ef72");
+	args_len = 2; /* "status", msg */
+	if (in_reply_to) {
+		args_len += 2;
+	}
+	if (auto_populate_reply_metadata) {
+		args_len += 2;
+	}
+	if (in_korea) {
+		args_len += 2;
+	}
+
+	char **args = g_new0(char *, args_len);
+	args_len = 0;
+	args[args_len++] = "status";
+	args[args_len++] = msg;
+	if (in_reply_to) {
+		in_reply_to_str = g_strdup_printf("%" G_GUINT64_FORMAT, in_reply_to);
+		args[args_len++] = "in_reply_to_status_id";
+		args[args_len++] = in_reply_to_str;
+	}
+	if (auto_populate_reply_metadata) {
+		args[args_len++] = "auto_populate_reply_metadata";
+		args[args_len++] = "true";
+	}
+	if (in_korea) {
+		place_id_str = g_strdup("c999e6a453e9ef72");
+		args[args_len++] = "place_id";
+		args[args_len++] = place_id_str;
 		in_reply_to = 1;
 	}
 
 	twitter_http(ic, TWITTER_STATUS_UPDATE_URL, twitter_http_post, ic, 1,
-	             args, in_reply_to ? 4 : 2);
-	g_free(args[3]);
+	             args, args_len);
+	if (in_reply_to_str) {
+	    g_free(in_reply_to_str);
+	}
+	if (place_id_str) {
+	    g_free(place_id_str);
+	}
+	g_free(args);
 }
 
 

--- a/protocols/twitter/twitter_lib.h
+++ b/protocols/twitter/twitter_lib.h
@@ -95,7 +95,7 @@ void twitter_get_mutes_ids(struct im_connection *ic, gint64 next_cursor);
 void twitter_get_noretweets_ids(struct im_connection *ic, gint64 next_cursor);
 void twitter_get_statuses_friends(struct im_connection *ic, gint64 next_cursor);
 
-void twitter_post_status(struct im_connection *ic, char *msg, guint64 in_reply_to);
+void twitter_post_status(struct im_connection *ic, char *msg, guint64 in_reply_to, gboolean auto_populate_reply_metadata);
 void twitter_direct_messages_new(struct im_connection *ic, char *who, char *message);
 void twitter_friendships_create_destroy(struct im_connection *ic, char *who, int create);
 void twitter_mute_create_destroy(struct im_connection *ic, char *who, int create);


### PR DESCRIPTION
With apologies to the author of #99, this patch uses the auto_populate_reply_metadata post argument to add a 'greply' (group reply) command. It seems to work in practice.

Possible future additions: a setting to make this the default 'reply' behaviour; support for the twitter API argument 'exclude_reply_user_ids' which allow given usernames to be untagged. Ref: https://developer.twitter.com/en/docs/tweets/tweet-updates