### PR TITLE
twitter: account_tag for nick and channel

### DIFF
--- a/doc/user-guide/commands.xml
+++ b/doc/user-guide/commands.xml
@@ -51,11 +51,11 @@
 					</para>
 					
 					<para>
-						By default all your Twitter contacts will appear in a new channel called #twitter_yourusername. You can change this behaviour using the <emphasis>mode</emphasis> setting (see <emphasis>help set mode</emphasis>).
+						By default all your Twitter contacts will appear in a new channel called #&lt;account_tag&gt;. You can change this behaviour using the <emphasis>mode</emphasis> setting (see <emphasis>help set mode</emphasis>).
 					</para>
 					
 					<para>
-						To send tweets yourself, send them to the twitter_(yourusername) contact, or just write in the groupchat channel if you enabled that option.
+						To send tweets yourself, send them to the &lt;account_tag&gt; contact, or just write in the groupchat channel if you enabled that option.
 					</para>
 
 					<para>
@@ -1072,11 +1072,11 @@
 
 		<description>
 			<para>
-				By default, BitlBee will create a separate channel (called #twitter_yourusername) for all your Twitter contacts/messages.
+				By default, BitlBee will create a separate channel (called #&lt;account_tag&gt;) for all your Twitter contacts/messages.
 			</para>
 
 			<para>
-				If you don't want an extra channel, you can set this setting to "one" (everything will come from one nick, twitter_yourusername), or to "many" (individual nicks for everyone).
+				If you don't want an extra channel, you can set this setting to "one" (everything will come from one nick, &lt;account_tag&gt;), or to "many" (individual nicks for everyone).
 			</para>
 			
 			<para>
@@ -1084,7 +1084,7 @@
 			</para>
 			
 			<para>
-				With modes "many" and "one", you can post tweets by /msg'ing the twitter_yourusername contact. In mode "chat", messages posted in the Twitter channel will also be posted as tweets.
+				With modes "many" and "one", you can post tweets by /msg'ing the &lt;account_tag&gt; contact. In mode "chat", messages posted in the Twitter channel will also be posted as tweets.
 			</para>
 		</description>
 

--- a/protocols/twitter/twitter_lib.c
+++ b/protocols/twitter/twitter_lib.c
@@ -954,13 +954,11 @@ static void twitter_status_show_chat(struct im_connection *ic, struct twitter_xm
 static void twitter_status_show_msg(struct im_connection *ic, struct twitter_xml_status *status)
 {
 	struct twitter_data *td = ic->proto_data;
-	char from[MAX_STRING] = "";
-	char *prefix = NULL, *text = NULL;
+	char *from = NULL, *prefix = NULL, *text = NULL;
 	gboolean me = g_strcasecmp(td->user, status->user->screen_name) == 0;
 
 	if (td->flags & TWITTER_MODE_ONE) {
-		g_snprintf(from, sizeof(from) - 1, "%s_%s", td->prefix, ic->acc->user);
-		from[MAX_STRING - 1] = '\0';
+		from = ic->acc->tag;
 	}
 
 	if (td->flags & TWITTER_MODE_ONE) {
@@ -975,7 +973,7 @@ static void twitter_status_show_msg(struct im_connection *ic, struct twitter_xml
 	text = twitter_msg_add_id(ic, status, prefix ? prefix : "");
 
 	imcb_buddy_msg(ic,
-	               *from ? from : status->user->screen_name,
+	               from ? from : status->user->screen_name,
 	               text ? text : status->text, 0, status->created_at);
 
 	g_free(text);


### PR DESCRIPTION
- twitter account is accessible now either under <account_tag> nickname or through #<account_tag> channel
- in contrast to status quo (twitter_<handle> / #twitter_<handle>) it  enables user to have a consistent namings, configurable by setting
   particular twitter account's tag
Avoid sending pings every time a new message is send in the twitter channel and only when the nick is nickname is mentioned.

Credit goes to @mkoskar (https://bugs.bitlbee.org/ticket/1173).
Rebased on current git