### PR TITLE
Use python3 when python is not available

### DIFF
--- a/configure
+++ b/configure
@@ -775,7 +775,12 @@ elif [ "$otr" = "plugin" ]; then
 fi
 
 if [ -z "$PYTHON" ]; then
-	PYTHON=python
+	for pp in python python3 python2; do
+		if which $pp > /dev/null; then
+			PYTHON=$pp
+			break
+		fi
+	done
 fi
 
 if [ "$doc" = "1" ]; then
@@ -979,6 +984,7 @@ else
 	echo '  systemd disabled.'
 fi
 
+echo '  Using python: '$PYTHON
 echo '  Using event handler: '$events
 echo '  Using SSL library: '$ssl
 #echo '  Building with these storage backends: '$STORAGES

--- a/debian/changelog
+++ b/debian/changelog
@@ -17,6 +17,9 @@ bitlbee (3.6-2) UNRELEASED; urgency=medium
   [ Debian Janitor ]
   * Upgrade to newer source format.
 
+  [ Jelmer Vernooĳ ]
+  * Use python3 since python2 is being removed. Closes: #942954
+
  -- Debian Janitor <janitor@jelmer.uk>  Thu, 21 Mar 2019 00:10:27 +0000
 
 bitlbee (3.6-1.1) unstable; urgency=medium

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Wilmer van der Gaast <wilmer@gaast.net>
 Uploaders: Jelmer Vernooĳ <jelmer@debian.org>
 Standards-Version: 3.9.8
-Build-Depends: libglib2.0-dev (>= 2.4), libevent-dev, libgnutls28-dev | libgnutls-dev | gnutls-dev, po-debconf, libpurple-dev, libotr5-dev, debhelper (>= 9), python
+Build-Depends: libglib2.0-dev (>= 2.4), libevent-dev, libgnutls28-dev | libgnutls-dev | gnutls-dev, po-debconf, libpurple-dev, libotr5-dev, debhelper (>= 9), python3
 Homepage: https://www.bitlbee.org/
 Vcs-Git: https://github.com/bitlbee/bitlbee
 Vcs-Browser: https://github.com/bitlbee/bitlbee


### PR DESCRIPTION
Use python3 when python is not available.

Also, use python3 in the debian packaging since python2 is going away.
