### PR TITLE
gitignore: add debian subdirs and some tooling output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,12 @@ cov-int
 bitlbee.service
 bitlbee@.service
 *~
+debian/bitlbee-common
+debian/bitlbee-dev
+debian/bitlbee-libpurple
+debian/bitlbee-plugin-otr
+debian/build-libpurple
+debian/build-native
+debian/files
+.clangd
+compile_commands.json


### PR DESCRIPTION
A previous commit removed debian/ from gitignore, but it still contains
output from the deb build process. So instead of throwing the whole dir
in, I added the entries for the stuff that shows up as untracked in my
working copy.

---

@jelmer since you did b28d55aa41231f05c39869f088d34e8327580f76