### PR TITLE
Properly terminate bitlbee with systemctl

### DIFF
--- a/init/bitlbee.service.in
+++ b/init/bitlbee.service.in
@@ -3,7 +3,7 @@ Description=BitlBee IRC/IM gateway
 
 [Service]
 ExecStart=@sbindir@bitlbee -F -n
-KillMode=process
+KillMode=control-group
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Fixes the bug I posted here: https://bugs.bitlbee.org/ticket/1323

Environment : archlinux

Additional plugin: bitlbee-facebook

Steps to reproduce:
- verify that 0 bitlbee processes are running
- `$ sudo systemctl start bitlbee`
- connect to bitlbee server
- observe that 3 bitlbee processes are running
- `$ sudo systemctl stop bitlbee`
- 2 bitlbee processes remain 

