### PR TITLE
docs: fix simple typo, exsist -> exist

### DIFF
--- a/protocols/twitter/twitter_lib.c
+++ b/protocols/twitter/twitter_lib.c
@@ -928,7 +928,7 @@ static void twitter_status_show_chat(struct im_connection *ic, struct twitter_xm
 	gboolean me = g_strcasecmp(td->user, status->user->screen_name) == 0;
 	char *msg;
 
-	// Create a new groupchat if it does not exsist.
+	// Create a new groupchat if it does not exist.
 	gc = twitter_groupchat_init(ic);
 
 	if (!me) {


### PR DESCRIPTION
There is a small typo in protocols/twitter/twitter_lib.c.

Should read `exist` rather than `exsist`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md