### PR TITLE
xmpp xep-0191/blocklist

### DIFF
--- a/protocols/jabber/Makefile
+++ b/protocols/jabber/Makefile
@@ -12,7 +12,7 @@ _SRCDIR_ := $(_SRCDIR_)protocols/jabber/
 endif
 
 # [SH] Program variables
-objects = conference.o io.o iq.o jabber.o jabber_util.o message.o presence.o s5bytestream.o sasl.o si.o hipchat.o
+objects = conference.o io.o iq.o jabber.o jabber_util.o message.o presence.o s5bytestream.o sasl.o si.o hipchat.o block.o
 
 LFLAGS += -r
 

--- a/protocols/jabber/block.c
+++ b/protocols/jabber/block.c
@@ -1,0 +1,94 @@
+/***************************************************************************\
+*                                                                           *
+*  BitlBee - An IRC to IM gateway                                           *
+*  Jabber module - Handling of blocking                                     *
+*                                                                           *
+*  Copyright 2021 / <>                                                      *
+*                                                                           *
+*  This program is free software; you can redistribute it and/or modify     *
+*  it under the terms of the GNU General Public License as published by     *
+*  the Free Software Foundation; either version 2 of the License, or        *
+*  (at your option) any later version.                                      *
+*                                                                           *
+*  This program is distributed in the hope that it will be useful,          *
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of           *
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+*  GNU General Public License for more details.                             *
+*                                                                           *
+*  You should have received a copy of the GNU General Public License along  *
+*  with this program; if not, write to the Free Software Foundation, Inc.,  *
+*  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.              *
+*                                                                           *
+\***************************************************************************/
+
+#include "jabber.h"
+
+int jabber_block_feature(struct im_connection *ic)
+{
+	struct jabber_data *jd = ic->proto_data;
+	GSList *features = jd->features;
+	int foundbk = FALSE;
+	struct prpl *prpl = ic->acc->prpl;
+
+	while (features) {
+		if (!strcmp(features->data, XMLNS_BLOCK)) {
+			foundbk = TRUE;
+		}
+		features = g_slist_next(features);
+	}
+
+	if (foundbk) {
+		prpl->add_deny = jabber_buddy_block;
+		prpl->rem_deny = jabber_buddy_unblock;
+		prpl->add_permit = jabber_buddy_permit;
+		prpl->rem_permit = jabber_buddy_unpermit;
+	} else {
+		prpl->add_deny = NULL;
+		prpl->rem_deny = NULL;
+		prpl->add_permit = NULL;
+		prpl->rem_permit = NULL;
+	}
+
+	return foundbk;
+}
+
+void jabber_buddy_blockunblock(struct im_connection *ic, char *who, int block)
+{
+	struct xt_node *node, *query;
+	struct jabber_buddy *bud;
+	char *s;
+
+	if ((s = strchr(who, '=')) && jabber_chat_by_jid(ic, s + 1)) {
+		bud = jabber_buddy_by_ext_jid(ic, who, 0);
+	} else {
+		bud = jabber_buddy_by_jid(ic, who, GET_BUDDY_BARE_OK);
+	}
+
+	node = xt_new_node("item", NULL, NULL);
+	xt_add_attr(node, "jid", bud ? bud->full_jid : who);
+
+	node = xt_new_node(block ? "block" : "unblock", NULL, node);
+	xt_add_attr(node, "xmlns", XMLNS_BLOCK);
+
+	query = jabber_make_packet("iq", "set", NULL, node);
+
+	jabber_write_packet(ic, query);
+	xt_free_node(query);
+}
+
+void jabber_buddy_block(struct im_connection *ic, char *who)
+{
+	jabber_buddy_blockunblock(ic, who, TRUE);
+}
+
+void jabber_buddy_unblock(struct im_connection *ic, char *who)
+{
+	jabber_buddy_blockunblock(ic, who, FALSE);
+}
+
+void jabber_buddy_permit(struct im_connection *ic, char *who)
+{
+}
+void jabber_buddy_unpermit(struct im_connection *ic, char *who)
+{
+}

--- a/protocols/jabber/jabber.h
+++ b/protocols/jabber/jabber.h
@@ -108,6 +108,7 @@ struct jabber_data {
 	GHashTable *node_cache;
 	GHashTable *buddies;
 
+	GSList *features;
 	GSList *filetransfers;
 	GSList *streamhosts;
 	int have_streamhosts;
@@ -243,6 +244,7 @@ struct jabber_transfer {
 #define XMLNS_FILETRANSFER "http://jabber.org/protocol/si/profile/file-transfer" /* XEP-0096 */
 #define XMLNS_BYTESTREAMS  "http://jabber.org/protocol/bytestreams"              /* XEP-0065 */
 #define XMLNS_IBB          "http://jabber.org/protocol/ibb"                      /* XEP-0047 */
+#define XMLNS_BLOCK        "urn:xmpp:blocking"                                   /* XEP-0191 */
 
 /* Hipchat protocol extensions*/
 #define XMLNS_HIPCHAT         "http://hipchat.com"
@@ -282,6 +284,13 @@ xt_status jabber_pkt_message(struct xt_node *node, gpointer data);
 xt_status jabber_pkt_presence(struct xt_node *node, gpointer data);
 int presence_send_update(struct im_connection *ic);
 int presence_send_request(struct im_connection *ic, char *handle, char *request);
+
+/* block.c */
+void jabber_buddy_block(struct im_connection *ic, char *who);
+void jabber_buddy_unblock(struct im_connection *ic, char *who);
+void jabber_buddy_permit(struct im_connection *ic, char *who);
+void jabber_buddy_unpermit(struct im_connection *ic, char *who);
+int jabber_block_feature(struct im_connection *ic);
 
 /* jabber_util.c */
 char *set_eval_priority(set_t *set, char *value);


### PR DESCRIPTION
jabber_data now carries a feature list which is filled at login. repeated filling does not destroy duplicates, probably not an issue for now?