### PR TITLE
root_commands: prevent linker error when plugins are disabled

### DIFF
--- a/root_commands.c
+++ b/root_commands.c
@@ -1168,6 +1168,7 @@ static void prplstr(GList *prpls, GString *gstr)
 	g_list_free(prpls);
 }
 
+#ifdef WITH_PLUGINS
 static void cmd_plugins_info(irc_t *irc, char **cmd)
 {
 	GList *l;
@@ -1201,6 +1202,7 @@ static void cmd_plugins_info(irc_t *irc, char **cmd)
 		irc_rootmsg(irc, "  URL: %s", info->url);
 	}
 }
+#endif
 
 static void cmd_plugins(irc_t *irc, char **cmd)
 {
@@ -1208,7 +1210,9 @@ static void cmd_plugins(irc_t *irc, char **cmd)
 	GString *gstr;
 
 	if (cmd[1] && g_strcasecmp(cmd[1], "info") == 0) {
+#ifdef WITH_PLUGINS
 		cmd_plugins_info(irc, cmd);
+#endif
 		return;
 	}
 


### PR DESCRIPTION
This commit fixes compilation issue with disabled plugin support (`./configure --plugins=0`), where `get_plugins` function is unavailable. The problem has been introduced with addition of new `plugins info` subcommand, where `get_plugins` is used in `cmd_plugins_info` function, which should be conditionally available only if `WITH_PLUGINS` is defined.

Bug: https://bugs.gentoo.org/739510
Bug: https://bugs.gentoo.org/617604
Fixes: 6908ab747d1e ("Add 'plugins info' subcommand, only show plugin details there")

Here are relevant lines from build log without this fix:
```
* Compiling root_commands.c
x86_64-gentoo-linux-musl-gcc -c -march=native -O2 -pipe -frecord-gcc-switches -I/var/tmp/portage/net-im/bitlbee-9999/work/bitlbee-9999 -I/var/tmp/portage/net-im/bitlbee-9999/work/bitlbee-9999/lib -I/var/tmp/portage/net-im/bitlbee-9999/work/bitlbee-9999/protocols -I.  -DHAVE_CONFIG_H -D_GNU_SOURCE -Wall -Wformat -Werror=format-security -pthread -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include -MMD -MF .depend/root_commands.o.d -fPIE root_commands.c -o root_commands.o
root_commands.c: In function 'cmd_plugins_info':
root_commands.c:1178:11: warning: implicit declaration of function
'get_plugins'; did you mean
'getlogin'? [-Wimplicit-function-declaration]
 1178 |  for (l = get_plugins(); l; l = l->next) {
      |           ^~~~~~~~~~~
      |           getlogin
root_commands.c:1178:9: warning: assignment to 'GList *' {aka 'struct
_GList *'} from 'int' makes pointer from integer without a cast
[-Wint-conversion]
 1178 |  for (l = get_plugins(); l; l = l->next) {
      |         ^

* Linking bitlbee
x86_64-gentoo-linux-musl-gcc bitlbee.o dcc.o help.o ipc.o irc.o irc_im.o irc_cap.o irc_channel.o irc_commands.o irc_send.o irc_user.o irc_util.o nick.o  query.o root_commands.o set.o storage.o storage_xml.o auth.o unix.o conf.o log.o lib/lib.o protocols/protocols.o -o bitlbee -pie -Wl,-O1 -Wl,--as-needed -Wl,--defsym=__gentoo_check_ldflags__=0 -Wl,-O1 -Wl,--as-needed -Wl,--defsym=__gentoo_check_ldflags__=0 -lm -Wl,-O1 -Wl,--as-needed -Wl,--defsym=__gentoo_check_ldflags__=0 -Wl,--export-dynamic -lgmodule-2.0 -pthread -lglib-2.0 -Wl,-O1 -Wl,--as-needed -Wl,--defsym=__gentoo_check_ldflags__=0 -lgnutls -lgcrypt -lgpg-error -Wl,-O1 -Wl,--as-needed -Wl,--defsym=__gentoo_check_ldflags__=0 -lresolv -Wl,-O1 -Wl,--as-needed -Wl,--defsym=__gentoo_check_ldflags__=0
/usr/lib/gcc/x86_64-gentoo-linux-musl/9.3.0/../../../../x86_64-gentoo-linux-musl/bin/ld:
root_commands.o: in function `cmd_plugins':
root_commands.c:(.text+0x73a): undefined reference to `get_plugins'
collect2: error: ld returned 1 exit status
make: *** [Makefile:167: bitlbee] Error 1
```