### PR TITLE
Accomodate filenames containing spaces in a DCC transfer.

### DIFF
--- a/dcc.c
+++ b/dcc.c
@@ -210,7 +210,7 @@ int dccs_send_request(struct dcc_file_transfer *df, irc_user_t *iu, struct socka
 
 	port = ntohs(port);
 
-	cmd = g_strdup_printf("\001DCC SEND %s %s %u %zu\001",
+	cmd = g_strdup_printf("\001DCC SEND \"%s\" %s %u %zu\001",
 	                      df->ft->file_name, ipaddr, port, df->ft->file_size);
 
 	irc_send_msg_raw(iu, "PRIVMSG", iu->irc->user->nick, cmd);


### PR DESCRIPTION
Many (most?) IRC clients accomodate receiving files that contain spaces in their names by having quotes surround the file name.

This quick fix allows bitlbee to handle that case.

An alternative implementation option would be to allow selecting either quotes surrounding the filename, or replacing all spaces in the offered file name using underbar characters.

File names containing quotes should probably receive additional processing, in order to ensure the quotes internal to the filename are properly escaped.

This patch, however, allows me to exchange files containing spaces in the names with a colleague who uses XMPP via Adium, with my client being a combination of bitlbee and ERC (under emacs).