### PR TITLE
Solaris 10 Fixes

### DIFF
--- a/configure
+++ b/configure
@@ -927,6 +927,9 @@ SunOS )
 	echo 'EFLAGS+=-lresolv -lnsl -lsocket' >> Makefile.settings
 	echo 'STRIP=\# skip strip' >> Makefile.settings
 	echo '#define NO_FD_PASSING' >> config.h
+	if [ "$arch_rel" = "5.10" ]; then
+		echo '#define NO_STRCASESTR' >> config.h
+	fi
 ;;
 AIX )
 	echo 'EFLAGS+=-Wl,-brtl' >> Makefile.settings

--- a/configure
+++ b/configure
@@ -55,15 +55,20 @@ ldap=0
 pie=1
 
 arch=$(uname -s)
+arch_rel=$(uname -r)
 
 GLIB_MIN_VERSION=2.32
 
-# Cygwin and Darwin don't support PIC/PIE
+# Cygwin, Darwin and SunOS < 5.11 do not support PIC/PIE
 case "$arch" in
 	CYGWIN* )
 		pie=0;;
 	Darwin )
 		pie=0;;
+	SunOS )
+		if [ "$arch_rel" = "5.10" ]; then
+			pie=0;;
+		fi
 esac
 
 get_version() {

--- a/lib/canohost.c
+++ b/lib/canohost.c
@@ -122,7 +122,7 @@ ipv64_normalise_mapped(struct sockaddr_storage *addr, socklen_t *len)
 	struct sockaddr_in6 *a6 = (struct sockaddr_in6 *)addr;
 	struct sockaddr_in *a4 = (struct sockaddr_in *)addr;
 	struct in_addr inaddr;
-	u_int16_t port;
+	uint16_t port;
 
 	if (addr->ss_family != AF_INET6 ||
 	    !IN6_IS_ADDR_V4MAPPED(&a6->sin6_addr))

--- a/lib/misc.c
+++ b/lib/misc.c
@@ -792,3 +792,21 @@ guint b_istr_hash(gconstpointer v)
 
 	return h;
 }
+
+#ifdef NO_STRCASESTR
+char* strcasestr(const char* haystack, const char* needle)
+{
+	size_t haystackn = strlen(haystack);
+	size_t needlen = strlen(needle);
+
+	const char *p = haystack;
+	while (haystackn >= needlen) {
+		if (g_strncasecmp(p, needle, needlen) == 0) {
+		    return (char*) p;
+		}
+		p++;
+		haystackn--;
+	}
+	return NULL;
+}
+#endif


### PR DESCRIPTION
This PR contains the changes I had to make to get bitlbee compiling under Solaris 10.

The most major changes are in the configure script updating it to be Solaris /bin/sh compatible, apart from that it's uint16_t over u_int16_t and a strcasestr compatability function.

If you want some but not all parts of this let me know and I'll split it up in separate PRs, creating this in go to see wheter or not you migth accept changes like this in the first place.