### PR TITLE
configure: Fix syntax

### DIFF
--- a/configure
+++ b/configure
@@ -67,8 +67,9 @@ case "$arch" in
 		pie=0;;
 	SunOS )
 		if [ "$arch_rel" = "5.10" ]; then
-			pie=0;;
+			pie=0
 		fi
+		;;
 esac
 
 get_version() {


### PR DESCRIPTION
Configure script was completely broken (at least with `bash`). Use shellcheck plz