### PR TITLE
nogaim: Match case in imc_away_state_find()

### DIFF
--- a/protocols/nogaim.c
+++ b/protocols/nogaim.c
@@ -836,7 +836,7 @@ static char *imc_away_state_find(GList *gcm, char *away, char **message)
 						*message = NULL;
 					}
 
-					return imc_away_alias_list[i][j];
+					return m->data;
 				}
 			}
 		}


### PR DESCRIPTION
## In short
* Match casing with provided list of statuses in `imc_away_state_find()`
  * If `dnd` given as a status, Bitlbee will always match case as `dnd` and *not* use `DND` from alias list
  * [Fixes `bitlbee-discord` when doing e.g. `/away Busy - some reason`](https://github.com/sm00th/bitlbee-discord/pull/230#issuecomment-1005468508 )
  * Changes Bitlbee plugin API, shouldn't cause issues but worthwhile investigating

*Thanks to @sm00th for troubleshooting help and the suggested fix!*

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★☆ *2/3* | Removes gotcha from status API, fixes `bitlbee-discord`
Risk | ★★☆ *2/3* | Changes how plugin API handles status aliases
Intrusiveness | ★☆☆ *1/3* | Small set of changes, shouldn't interfere with other pull requests

## Details

Match the provided away-state case when searching for an alias, better matching expectations.

Technically this is a breaking behavior change to Bitlbee's plugin API, even if this behavior may make more sense.

For example, [`bitlbee-discord` provides this](https://github.com/sm00th/bitlbee-discord/blob/607f9887ca85f246e970778e3d40aa5c346365a7/src/discord.c#L295-L298 ):
```
    m = g_list_prepend(m, "invisible");
    m = g_list_prepend(m, "dnd");
    m = g_list_prepend(m, "online");
    m = g_list_prepend(m, "idle");
```

Before this pull request, Bitlbee would use `DND` instead if an away state matched an alias (e.g. `Busy`).

Afterwards, Bitlbee will always match `dnd` as given by `bitlbee-discord`.

## Testing

To simplify matters, this was tested using a minimal reproducer that @sm00th made - thank you!

### Steps

1.  [Download the simplified `imc_away_state_find.c` test case](https://github.com/sm00th/bitlbee-discord/issues/229#issuecomment-1004638320 )
```
wget https://gist.githubusercontent.com/sm00th/df99f857ec429b7b2756ae98ed78aca8/raw/931bca952242725331553862554e8268d7bc95cd/imc_away_state_find.c
```
2.  Compile without changes
```
gcc -Wall -g -o imc_away_state_find imc_away_state_find.c $(pkg-config --cflags --libs glib-2.0)
```
3.  Run with `"DND - resting after trip"`, record result
```
./imc_away_state_find "DND - resting after trip"
```
4.  Run with `"Busy - resting after trip"`, record result
```
./imc_away_state_find "Busy - resting after trip"
```
5.  Save a patched copy of `imc_away_state_find.c` as `imc_away_state_find_bitlbee_pr_test.c`
```diff
--- imc_away_state_find.c
+++ imc_away_state_find_bitlbee_pr_test.c
@@ -53,7 +53,7 @@
 						*message = NULL;
 					}
 
-					return imc_away_alias_list[i][j];
+					return m->data;
 				}
 			}
 		}
```
6.  Compile **with changes**
```
gcc -Wall -g -o imc_away_state_find_bitlbee_pr_test imc_away_state_find_bitlbee_pr_test.c $(pkg-config --cflags --libs glib-2.0)
```
7.  Run patched version with `"DND - resting after trip"`, record result
```
./imc_away_state_find_bitlbee_pr_test "DND - resting after trip"
```
8.  Run patched version with `"Busy - resting after trip"`, record result
```
./imc_away_state_find_bitlbee_pr_test "Busy - resting after trip"
```

### Before

```
./imc_away_state_find "DND - resting after trip"
away=dnd
```

(*Equivalent to `/away DND - resting after trip`.*)

...gives `dnd`, which matches what was given to Bitlbee.


```
./imc_away_state_find "Busy - resting after trip"
away=DND
```

(*Equivalent to `/away Busy - resting after trip`.*)

...gives `DND`, which does **not** match what was given to Bitlbee.  The capitalization is derived from using Bitlbee's built-in alias list.

### After

Bitlbee always uses the casing provided by the plugin's away states.

```
./imc_away_state_find_bitlbee_pr_test "DND - resting after trip"
away=dnd
./imc_away_state_find_bitlbee_pr_test "Busy - resting after trip"
away=dnd
```

(*As before, equivalent to `/away DND - resting after trip` and `/away Busy - resting after trip`.*)

...both give `dnd`, which matches what was given to Bitlbee.

If `bitlbee-discord` had instead specified `dNd`, `dNd` would be used.
