### PR TITLE
Fix last places breaking strict-aliasing rules

### DIFF
--- a/configure
+++ b/configure
@@ -311,7 +311,7 @@ if [ "$debug" = "1" ]; then
 	echo 'DEBUG=1' >> Makefile.settings
 	CFLAGS="$CFLAGS -g3 -DDEBUG -O0"
 else
-	[ -z "$CFLAGS" ] && CFLAGS="-g -O2 -fno-strict-aliasing"
+	[ -z "$CFLAGS" ] && CFLAGS="-g -O2"
 fi
 
 if [ "$pie" = "1" ]; then

--- a/lib/json.c
+++ b/lib/json.c
@@ -139,7 +139,7 @@ static int new_value
 				return 0;
 			}
 
-			value->_reserved.object_mem = (*(char **) &value->u.object.values) + values_size;
+			value->_reserved.object_mem = (void *) (((char *) value->u.object.values) + values_size);
 
 			value->u.object.length = 0;
 			break;
@@ -406,7 +406,8 @@ json_value * json_parse_ex(json_settings * settings,
 					case json_object:
 
 						if (state.first_pass) {
-							(*(json_char **) &top->u.object.values) += string_length + 1;
+							json_char **chars = (json_char **) &top->u.object.values;
+							chars[0] += string_length + 1;
 						} else {
 							top->u.object.values [top->u.object.length].name
 							        = (json_char *) top->_reserved.object_mem;


### PR DESCRIPTION
This PR fixes last two places in `lib/json.c` breaking strict-aliasing rules. The fix is backported from upstream https://github.com/json-parser/json-parser. `-fno-strict-aliasing` seems to be no longer necessary, therefore, I dropped it out of default `CFLAGS`. The fix is related to downstream bug https://bugs.gentoo.org/861371.