### PR TITLE
Fixes related to external-json-parser

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,12 @@
 
 # Program variables
 objects = bitlbee.o dcc.o help.o ipc.o irc.o irc_im.o irc_cap.o irc_channel.o irc_commands.o irc_send.o irc_user.o irc_util.o nick.o $(OTR_BI) query.o root_commands.o set.o storage.o $(STORAGE_OBJS) auth.o $(AUTH_OBJS) unix.o conf.o log.o
-headers = $(wildcard $(_SRCDIR_)*.h $(_SRCDIR_)lib/*.h $(_SRCDIR_)protocols/*.h)
+allheaders = $(wildcard $(_SRCDIR_)*.h $(_SRCDIR_)lib/*.h $(_SRCDIR_)protocols/*.h)
+ifeq ($(EXTERNAL_JSON_PARSER),1)
+headers = $(filter-out $(_SRCDIR_)lib/json.h,$(allheaders))
+else
+headers = $(allheaders)
+endif
 subdirs = lib protocols
 
 OUTFILE = bitlbee

--- a/configure
+++ b/configure
@@ -867,6 +867,11 @@ CYGWIN* )
 	pkgconfiglibs="-L${libdir} -lbitlbee -no-undefined"
 esac
 
+pkgconfigrequires='glib-2.0'
+if [ "$external_json_parser" = '1' ]; then
+	pkgconfigrequires="$pkgconfigrequires json-parser"
+fi
+
 cat <<EOF >bitlbee.pc
 prefix=$prefix
 includedir=$includedir
@@ -876,7 +881,7 @@ datadir=$datadir
 
 Name: bitlbee
 Description: IRC to IM gateway
-Requires: glib-2.0
+Requires: $pkgconfigrequires
 Version: $BITLBEE_VERSION
 Libs: $pkgconfiglibs
 Cflags: -I\${includedir}

--- a/configure
+++ b/configure
@@ -329,7 +329,6 @@ fi
 echo "LDFLAGS=$LDFLAGS" >> Makefile.settings
 
 echo "CFLAGS=$CFLAGS $CPPFLAGS" >> Makefile.settings
-echo CFLAGS+=-I"${srcdir}" -I"${srcdir}"/lib -I"${srcdir}"/protocols -I. >> Makefile.settings
 
 echo CFLAGS+=-DHAVE_CONFIG_H -D_GNU_SOURCE >> Makefile.settings
 
@@ -420,10 +419,12 @@ echo "EXTERNAL_JSON_PARSER=$external_json_parser" >> Makefile.settings
 if [ "$external_json_parser" = "1" ]; then
     # shellcheck disable=SC2129
     echo "CFLAGS+=$(pkg-config --cflags json-parser)" >> Makefile.settings
+    echo "CFLAGS+=-DUSE_EXTERNAL_JSON_PARSER" >> Makefile.settings
     echo "LDFLAGS_BITLBEE+=$(pkg-config --libs json-parser)" >> Makefile.settings
     echo "LDFLAGS_TESTS+=$(pkg-config --libs json-parser)" >> Makefile.settings
 fi
 
+echo CFLAGS+=-I"${srcdir}" -I"${srcdir}"/lib -I"${srcdir}"/protocols -I. >> Makefile.settings
 
 detect_gnutls()
 {

--- a/lib/json.h
+++ b/lib/json.h
@@ -28,6 +28,10 @@
  * SUCH DAMAGE.
  */
 
+#ifdef USE_EXTERNAL_JSON_PARSER
+#error Bitlbee was configured to use system json-parser, this header file should not be used.
+#endif
+
 #ifndef _JSON_H
 #define _JSON_H
 

--- a/lib/json_util.h
+++ b/lib/json_util.h
@@ -21,7 +21,7 @@
 *                                                                           *
 ****************************************************************************/
 
-#include "json.h"
+#include <json.h>
 
 #define JSON_O_FOREACH(o, k, v) \
 	char *k; json_value *v; int __i; \

--- a/lib/oauth2.c
+++ b/lib/oauth2.c
@@ -41,7 +41,7 @@
 #include "http_client.h"
 #include "oauth2.h"
 #include "oauth.h"
-#include "json.h"
+#include <json.h>
 #include "json_util.h"
 #include "url.h"
 


### PR DESCRIPTION
This PR fixes multiple issues for those who wish to use system `libjsonparser`. First two commits are related to external plugins, the last commit corrects which `json.h` should be used when `external-json-parser` is set. See commit messages for more info.