### PR TITLE
Add support for using libmd for MD5 functions

### DIFF
--- a/configure
+++ b/configure
@@ -49,6 +49,7 @@ otr=0
 
 events=glib
 external_json_parser=auto
+external_md5=auto
 ssl=auto
 
 pam=0
@@ -160,6 +161,7 @@ Option		Description				Default
 --ssl=...	SSL library to use (gnutls, nss, openssl, auto)
 							$ssl
 --external_json_parser=0/1/auto	Use External JSON parser $external_json_parser
+--external_md5=0/1/auto	Use External MD5 routines $external_md5
 --systemd=0/1  Enable/disable systemd support $systemd
 
 
@@ -425,6 +427,18 @@ if [ "$external_json_parser" = "1" ]; then
     echo "LDFLAGS_TESTS+=$(pkg-config --libs json-parser)" >> Makefile.settings
 fi
 
+if [ "$external_md5" = "auto" ]; then
+	if pkg-config --exists libmd; then
+		external_md5=1
+	else
+		external_md5=0
+	fi
+fi
+if [ "$external_md5" = "1" ]; then
+    echo "CFLAGS+=-D_EXTERNAL_MD5 $(pkg-config --cflags libmd)" >> Makefile.settings
+    echo "LDFLAGS_BITLBEE+=$(pkg-config --libs libmd)" >> Makefile.settings
+    echo "LDFLAGS_TESTS+=$(pkg-config --libs libmd)" >> Makefile.settings
+fi
 
 detect_gnutls()
 {
@@ -1045,6 +1059,12 @@ if [ "$external_json_parser" = "1" ]; then
     echo '  Using system JSON parser.'
 else
     echo '  Using bundled JSON parser.'
+fi
+
+if [ "$external_md5" = "1" ]; then
+    echo '  Using system MD5 routines in libmd.'
+else
+    echo '  Using bundled MD5 routines.'
 fi
 
 echo '  Using event handler: '$events

--- a/lib/misc.c
+++ b/lib/misc.c
@@ -33,7 +33,11 @@
 #define BITLBEE_CORE
 #include "nogaim.h"
 #include "base64.h"
+#ifdef _EXTERNAL_MD5
+#include <md5.h>
+#else
 #include "md5.h"
+#endif
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -46,7 +50,11 @@
 #include <resolv.h>
 #endif
 
+#ifdef _EXTERNAL_MD5
+#include <md5.h>
+#else
 #include "md5.h"
+#endif
 #include "ssl_client.h"
 
 void strip_linefeed(gchar *text)

--- a/protocols/nogaim.h
+++ b/protocols/nogaim.h
@@ -48,7 +48,11 @@
 #include "account.h"
 #include "proxy.h"
 #include "query.h"
+#ifdef _EXTERNAL_MD5
+#include <md5.h>
+#else
 #include "md5.h"
+#endif
 #include "ft.h"
 
 #define BUDDY_ALIAS_MAXLEN 388   /* because MSN names can be 387 characters */


### PR DESCRIPTION
libmd is a library found on some Linux distributions that provides MD5 and other message digest functions.  It is generally found as a companion to the libbsd library.

This patch adds --external_md5=0/1/auto to let the builder select whether or not to build with the internal MD5 routines or link with libmd.

Signed-off-by: David Cantrell <dcantrell@redhat.com>