### PR TITLE
Use g_memdup2() with glib versions >= 2.68.0

### DIFF
--- a/bitlbee.h
+++ b/bitlbee.h
@@ -103,6 +103,13 @@ extern "C" {
 #define g_strcasecmp g_ascii_strcasecmp
 #define g_strncasecmp g_ascii_strncasecmp
 
+/* g_memdup() deprecated as of glib 2.68.0 */
+#ifdef GLIB_VERSION_2_68
+#define G_MEMDUP g_memdup2
+#else
+#define G_MEMDUP g_memdup
+#endif
+
 #ifndef G_GNUC_MALLOC
 /* Doesn't exist in GLib <=2.4 while everything else in BitlBee should
    work with it, so let's fake this one. */

--- a/bitlbee.h
+++ b/bitlbee.h
@@ -104,10 +104,8 @@ extern "C" {
 #define g_strncasecmp g_ascii_strncasecmp
 
 /* g_memdup() deprecated as of glib 2.68.0 */
-#ifdef GLIB_VERSION_2_68
-#define G_MEMDUP g_memdup2
-#else
-#define G_MEMDUP g_memdup
+#ifndef GLIB_VERSION_2_68
+#define g_memdup2 g_memdup
 #endif
 
 #ifndef G_GNUC_MALLOC

--- a/lib/http_client.c
+++ b/lib/http_client.c
@@ -371,7 +371,7 @@ static http_ret_t http_process_chunked_data(struct http_request *req, const char
 
 	if (chunk != req->cbuf) {
 		req->cblen = eos - chunk;
-		s = G_MEMDUP(chunk, req->cblen + 1);
+		s = g_memdup2(chunk, req->cblen + 1);
 		g_free(req->cbuf);
 		req->cbuf = s;
 	}
@@ -461,7 +461,7 @@ static gboolean http_handle_headers(struct http_request *req)
 
 	/* Separately allocated space for headers and body. */
 	req->sblen = req->body_size = req->reply_headers + req->bytes_read - req->reply_body;
-	req->sbuf = req->reply_body = G_MEMDUP(req->reply_body, req->body_size + 1);
+	req->sbuf = req->reply_body = g_memdup2(req->reply_body, req->body_size + 1);
 	req->reply_headers = g_realloc(req->reply_headers, end1 - req->reply_headers + 1);
 
 	if ((end1 = strchr(req->reply_headers, ' ')) != NULL) {
@@ -679,7 +679,7 @@ void http_flush_bytes(struct http_request *req, size_t len)
 	req->body_size -= len;
 
 	if (req->reply_body - req->sbuf >= 512) {
-		char *new = G_MEMDUP(req->reply_body, req->body_size + 1);
+		char *new = g_memdup2(req->reply_body, req->body_size + 1);
 		g_free(req->sbuf);
 		req->reply_body = req->sbuf = new;
 		req->sblen = req->body_size;

--- a/lib/http_client.c
+++ b/lib/http_client.c
@@ -371,7 +371,7 @@ static http_ret_t http_process_chunked_data(struct http_request *req, const char
 
 	if (chunk != req->cbuf) {
 		req->cblen = eos - chunk;
-		s = g_memdup(chunk, req->cblen + 1);
+		s = G_MEMDUP(chunk, req->cblen + 1);
 		g_free(req->cbuf);
 		req->cbuf = s;
 	}
@@ -461,7 +461,7 @@ static gboolean http_handle_headers(struct http_request *req)
 
 	/* Separately allocated space for headers and body. */
 	req->sblen = req->body_size = req->reply_headers + req->bytes_read - req->reply_body;
-	req->sbuf = req->reply_body = g_memdup(req->reply_body, req->body_size + 1);
+	req->sbuf = req->reply_body = G_MEMDUP(req->reply_body, req->body_size + 1);
 	req->reply_headers = g_realloc(req->reply_headers, end1 - req->reply_headers + 1);
 
 	if ((end1 = strchr(req->reply_headers, ' ')) != NULL) {
@@ -679,7 +679,7 @@ void http_flush_bytes(struct http_request *req, size_t len)
 	req->body_size -= len;
 
 	if (req->reply_body - req->sbuf >= 512) {
-		char *new = g_memdup(req->reply_body, req->body_size + 1);
+		char *new = G_MEMDUP(req->reply_body, req->body_size + 1);
 		g_free(req->sbuf);
 		req->reply_body = req->sbuf = new;
 		req->sblen = req->body_size;

--- a/lib/json_util.c
+++ b/lib/json_util.c
@@ -27,6 +27,13 @@
 
 #include "json_util.h"
 
+/* g_memdup() deprecated as of glib 2.68.0 */
+#ifdef GLIB_VERSION_2_68
+#define G_MEMDUP g_memdup2
+#else
+#define G_MEMDUP g_memdup
+#endif
+
 json_value *json_o_get(const json_value *obj, const json_char *name)
 {
 	int i;
@@ -60,7 +67,7 @@ char *json_o_strdup(const json_value *obj, const json_char *name)
 	json_value *ret = json_o_get(obj, name);
 
 	if (ret && ret->type == json_string && ret->u.string.ptr) {
-		return g_memdup(ret->u.string.ptr, ret->u.string.length + 1);
+		return G_MEMDUP(ret->u.string.ptr, ret->u.string.length + 1);
 	} else {
 		return NULL;
 	}

--- a/lib/json_util.c
+++ b/lib/json_util.c
@@ -29,9 +29,9 @@
 
 /* g_memdup() deprecated as of glib 2.68.0 */
 #ifdef GLIB_VERSION_2_68
-#define G_MEMDUP g_memdup2
+#define g_memdup2 g_memdup2
 #else
-#define G_MEMDUP g_memdup
+#define g_memdup2 g_memdup
 #endif
 
 json_value *json_o_get(const json_value *obj, const json_char *name)
@@ -67,7 +67,7 @@ char *json_o_strdup(const json_value *obj, const json_char *name)
 	json_value *ret = json_o_get(obj, name);
 
 	if (ret && ret->type == json_string && ret->u.string.ptr) {
-		return G_MEMDUP(ret->u.string.ptr, ret->u.string.length + 1);
+		return g_memdup2(ret->u.string.ptr, ret->u.string.length + 1);
 	} else {
 		return NULL;
 	}

--- a/lib/xmltree.c
+++ b/lib/xmltree.c
@@ -32,6 +32,13 @@
 #define g_strcasecmp g_ascii_strcasecmp
 #define g_strncasecmp g_ascii_strncasecmp
 
+/* g_memdup() deprecated as of glib 2.68.0 */
+#ifdef GLIB_VERSION_2_68
+#define G_MEMDUP g_memdup2
+#else
+#define G_MEMDUP g_memdup
+#endif
+
 static void xt_start_element(GMarkupParseContext *ctx, const gchar *element_name, const gchar **attr_names,
                              const gchar **attr_values, gpointer data, GError **error)
 {
@@ -363,7 +370,7 @@ struct xt_node *xt_dup(struct xt_node *node)
 	dup->name = g_strdup(node->name);
 	dup->flags = node->flags;
 	if (node->text) {
-		dup->text = g_memdup(node->text, node->text_len + 1);
+		dup->text = G_MEMDUP(node->text, node->text_len + 1);
 		dup->text_len = node->text_len;
 	}
 

--- a/lib/xmltree.c
+++ b/lib/xmltree.c
@@ -34,9 +34,9 @@
 
 /* g_memdup() deprecated as of glib 2.68.0 */
 #ifdef GLIB_VERSION_2_68
-#define G_MEMDUP g_memdup2
+#define g_memdup2 g_memdup2
 #else
-#define G_MEMDUP g_memdup
+#define g_memdup2 g_memdup
 #endif
 
 static void xt_start_element(GMarkupParseContext *ctx, const gchar *element_name, const gchar **attr_names,
@@ -370,7 +370,7 @@ struct xt_node *xt_dup(struct xt_node *node)
 	dup->name = g_strdup(node->name);
 	dup->flags = node->flags;
 	if (node->text) {
-		dup->text = G_MEMDUP(node->text, node->text_len + 1);
+		dup->text = g_memdup2(node->text, node->text_len + 1);
 		dup->text_len = node->text_len;
 	}
 

--- a/protocols/bee_user.c
+++ b/protocols/bee_user.c
@@ -200,7 +200,7 @@ void imcb_buddy_status(struct im_connection *ic, const char *handle, int flags, 
 	}
 
 	/* May be nice to give the UI something to compare against. */
-	old = G_MEMDUP(bu, sizeof(bee_user_t));
+	old = g_memdup2(bu, sizeof(bee_user_t));
 
 	/* TODO(wilmer): OPT_AWAY, or just state == NULL ? */
 	bu->flags = flags;
@@ -238,7 +238,7 @@ void imcb_buddy_status_msg(struct im_connection *ic, const char *handle, const c
 		return;
 	}
 
-	old = G_MEMDUP(bu, sizeof(bee_user_t));
+	old = g_memdup2(bu, sizeof(bee_user_t));
 
 	bu->status_msg = message && *message ? g_strdup(message) : NULL;
 

--- a/protocols/bee_user.c
+++ b/protocols/bee_user.c
@@ -200,7 +200,7 @@ void imcb_buddy_status(struct im_connection *ic, const char *handle, int flags, 
 	}
 
 	/* May be nice to give the UI something to compare against. */
-	old = g_memdup(bu, sizeof(bee_user_t));
+	old = G_MEMDUP(bu, sizeof(bee_user_t));
 
 	/* TODO(wilmer): OPT_AWAY, or just state == NULL ? */
 	bu->flags = flags;
@@ -238,7 +238,7 @@ void imcb_buddy_status_msg(struct im_connection *ic, const char *handle, const c
 		return;
 	}
 
-	old = g_memdup(bu, sizeof(bee_user_t));
+	old = G_MEMDUP(bu, sizeof(bee_user_t));
 
 	bu->status_msg = message && *message ? g_strdup(message) : NULL;
 

--- a/protocols/jabber/io.c
+++ b/protocols/jabber/io.c
@@ -62,7 +62,7 @@ int jabber_write(struct im_connection *ic, char *buf, int len)
 	if (jd->tx_len == 0) {
 		/* If the queue is empty, allocate a new buffer. */
 		jd->tx_len = len;
-		jd->txq = G_MEMDUP(buf, len);
+		jd->txq = g_memdup2(buf, len);
 
 		/* Try if we can write it immediately so we don't have to do
 		   it via the event handler. If not, add the handler. (In
@@ -133,7 +133,7 @@ static gboolean jabber_write_queue(struct im_connection *ic)
 	} else if (st > 0) {
 		char *s;
 
-		s = G_MEMDUP(jd->txq + st, jd->tx_len - st);
+		s = g_memdup2(jd->txq + st, jd->tx_len - st);
 		jd->tx_len -= st;
 		g_free(jd->txq);
 		jd->txq = s;

--- a/protocols/jabber/io.c
+++ b/protocols/jabber/io.c
@@ -62,7 +62,7 @@ int jabber_write(struct im_connection *ic, char *buf, int len)
 	if (jd->tx_len == 0) {
 		/* If the queue is empty, allocate a new buffer. */
 		jd->tx_len = len;
-		jd->txq = g_memdup(buf, len);
+		jd->txq = G_MEMDUP(buf, len);
 
 		/* Try if we can write it immediately so we don't have to do
 		   it via the event handler. If not, add the handler. (In
@@ -133,7 +133,7 @@ static gboolean jabber_write_queue(struct im_connection *ic)
 	} else if (st > 0) {
 		char *s;
 
-		s = g_memdup(jd->txq + st, jd->tx_len - st);
+		s = G_MEMDUP(jd->txq + st, jd->tx_len - st);
 		jd->tx_len -= st;
 		g_free(jd->txq);
 		jd->txq = s;

--- a/protocols/jabber/jabber.c
+++ b/protocols/jabber/jabber.c
@@ -802,7 +802,7 @@ void jabber_initmodule()
 	register_protocol(ret);
 
 	/* Another one for hipchat, which has completely different logins */
-	hipchat = g_memdup(ret, sizeof(struct prpl));
+	hipchat = G_MEMDUP(ret, sizeof(struct prpl));
 	hipchat->name = "hipchat";
 	register_protocol(hipchat);
 }

--- a/protocols/jabber/jabber.c
+++ b/protocols/jabber/jabber.c
@@ -802,7 +802,7 @@ void jabber_initmodule()
 	register_protocol(ret);
 
 	/* Another one for hipchat, which has completely different logins */
-	hipchat = G_MEMDUP(ret, sizeof(struct prpl));
+	hipchat = g_memdup2(ret, sizeof(struct prpl));
 	hipchat->name = "hipchat";
 	register_protocol(hipchat);
 }

--- a/protocols/purple/ft-direct.c
+++ b/protocols/purple/ft-direct.c
@@ -70,7 +70,7 @@ static gboolean prpl_xfer_write(struct file_transfer *ft, char *buffer, unsigned
 {
 	struct prpl_xfer_data *px = ft->data;
 
-	px->buf = g_memdup(buffer, len);
+	px->buf = G_MEMDUP(buffer, len);
 	px->buf_len = len;
 
 	//purple_xfer_ui_ready( px->xfer );

--- a/protocols/purple/ft-direct.c
+++ b/protocols/purple/ft-direct.c
@@ -70,7 +70,7 @@ static gboolean prpl_xfer_write(struct file_transfer *ft, char *buffer, unsigned
 {
 	struct prpl_xfer_data *px = ft->data;
 
-	px->buf = G_MEMDUP(buffer, len);
+	px->buf = g_memdup2(buffer, len);
 	px->buf_len = len;
 
 	//purple_xfer_ui_ready( px->xfer );

--- a/protocols/purple/purple.c
+++ b/protocols/purple/purple.c
@@ -1936,7 +1936,7 @@ void purple_initmodule()
 			continue;
 		}
 
-		ret = g_memdup(&funcs, sizeof(funcs));
+		ret = G_MEMDUP(&funcs, sizeof(funcs));
 		ret->name = ret->data = prot->info->id;
 		if (strncmp(ret->name, "prpl-", 5) == 0) {
 			ret->name += 5;

--- a/protocols/purple/purple.c
+++ b/protocols/purple/purple.c
@@ -1936,7 +1936,7 @@ void purple_initmodule()
 			continue;
 		}
 
-		ret = G_MEMDUP(&funcs, sizeof(funcs));
+		ret = g_memdup2(&funcs, sizeof(funcs));
 		ret->name = ret->data = prot->info->id;
 		if (strncmp(ret->name, "prpl-", 5) == 0) {
 			ret->name += 5;

--- a/protocols/twitter/twitter.c
+++ b/protocols/twitter/twitter.c
@@ -1116,7 +1116,7 @@ void twitter_initmodule()
 	register_protocol(ret);
 
 	/* And an identi.ca variant: */
-	ret = g_memdup(ret, sizeof(struct prpl));
+	ret = G_MEMDUP(ret, sizeof(struct prpl));
 	ret->name = "identica";
 	ret->options =  PRPL_OPT_NOOTR;
 	register_protocol(ret);

--- a/protocols/twitter/twitter.c
+++ b/protocols/twitter/twitter.c
@@ -1116,7 +1116,7 @@ void twitter_initmodule()
 	register_protocol(ret);
 
 	/* And an identi.ca variant: */
-	ret = G_MEMDUP(ret, sizeof(struct prpl));
+	ret = g_memdup2(ret, sizeof(struct prpl));
 	ret->name = "identica";
 	ret->options =  PRPL_OPT_NOOTR;
 	register_protocol(ret);

--- a/protocols/twitter/twitter_lib.c
+++ b/protocols/twitter/twitter_lib.c
@@ -646,7 +646,7 @@ static struct twitter_xml_status *twitter_xt_get_status(const json_value *node)
 			txs_free(rtxs);
 		}
 	} else if (text_value && text_value->type == json_string) {
-		txs->text = g_memdup(text_value->u.string.ptr, text_value->u.string.length + 1);
+		txs->text = G_MEMDUP(text_value->u.string.ptr, text_value->u.string.length + 1);
 		strip_html(txs->text);
 		expand_entities(&txs->text, node, extended_node);
 	}
@@ -673,7 +673,7 @@ static struct twitter_xml_status *twitter_xt_get_dm(const json_value *node)
 
 	JSON_O_FOREACH(node, k, v) {
 		if (strcmp("text", k) == 0 && v->type == json_string) {
-			txs->text = g_memdup(v->u.string.ptr, v->u.string.length + 1);
+			txs->text = G_MEMDUP(v->u.string.ptr, v->u.string.length + 1);
 			strip_html(txs->text);
 		} else if (strcmp("created_at", k) == 0 && v->type == json_string) {
 			struct tm parsed;

--- a/protocols/twitter/twitter_lib.c
+++ b/protocols/twitter/twitter_lib.c
@@ -646,7 +646,7 @@ static struct twitter_xml_status *twitter_xt_get_status(const json_value *node)
 			txs_free(rtxs);
 		}
 	} else if (text_value && text_value->type == json_string) {
-		txs->text = G_MEMDUP(text_value->u.string.ptr, text_value->u.string.length + 1);
+		txs->text = g_memdup2(text_value->u.string.ptr, text_value->u.string.length + 1);
 		strip_html(txs->text);
 		expand_entities(&txs->text, node, extended_node);
 	}
@@ -673,7 +673,7 @@ static struct twitter_xml_status *twitter_xt_get_dm(const json_value *node)
 
 	JSON_O_FOREACH(node, k, v) {
 		if (strcmp("text", k) == 0 && v->type == json_string) {
-			txs->text = G_MEMDUP(v->u.string.ptr, v->u.string.length + 1);
+			txs->text = g_memdup2(v->u.string.ptr, v->u.string.length + 1);
 			strip_html(txs->text);
 		} else if (strcmp("created_at", k) == 0 && v->type == json_string) {
 			struct tm parsed;


### PR DESCRIPTION
g_memdup() was deprecated in glib 2.68.0.  The new function is g_memdup2().  Still support building with older versions of glib via macros.

Signed-off-by: David Cantrell <dcantrell@redhat.com>