### PR TITLE
Migrate internal users of md5.h to using GChecksum directly

### DIFF
--- a/lib/md5.c
+++ b/lib/md5.c
@@ -27,9 +27,11 @@ void md5_finish(md5_state_t *ctx, guint8 digest[MD5_HASH_SIZE])
  * and finishes that one instead of the original */
 void md5_digest_keep(md5_state_t *ctx, guint8 digest[MD5_HASH_SIZE])
 {
-	md5_state_t copy = g_checksum_copy(*ctx);
+	gsize digest_len = MD5_HASH_SIZE;
+	GChecksum *copy = g_checksum_copy(*ctx);
 
-	md5_finish(&copy, digest);
+	g_checksum_get_digest(copy, digest, &digest_len);
+	g_checksum_free(copy);
 }
 
 void md5_free(md5_state_t *ctx)

--- a/lib/md5.h
+++ b/lib/md5.h
@@ -7,13 +7,18 @@
 typedef guint8 md5_byte_t;
 typedef GChecksum *md5_state_t;
 
-
 #define MD5_HASH_SIZE 16
 
-void md5_init(md5_state_t *);
-void md5_append(md5_state_t *, const guint8 *, unsigned int);
-void md5_finish(md5_state_t *, guint8 digest[MD5_HASH_SIZE]);
-void md5_digest_keep(md5_state_t *, guint8 digest[MD5_HASH_SIZE]);
-void md5_free(md5_state_t *);
+#ifdef __GNUC__
+#define __MD5_NON_PUBLIC_DEPRECATION__ __attribute__((deprecated("md5.h will be removed from Bitlbee's public API. Please use another library (such as GLib's gchecksum) instead")))
+#else
+#define __MD5_NON_PUBLIC_DEPRECATION__
+#endif
+
+void md5_init(md5_state_t *) __MD5_NON_PUBLIC_DEPRECATION__;
+void md5_append(md5_state_t *, const guint8 *, unsigned int) __MD5_NON_PUBLIC_DEPRECATION__;
+void md5_finish(md5_state_t *, guint8 digest[MD5_HASH_SIZE]) __MD5_NON_PUBLIC_DEPRECATION__;
+void md5_digest_keep(md5_state_t *, guint8 digest[MD5_HASH_SIZE]) __MD5_NON_PUBLIC_DEPRECATION__;
+void md5_free(md5_state_t *) __MD5_NON_PUBLIC_DEPRECATION__;
 
 #endif

--- a/protocols/jabber/jabber.h
+++ b/protocols/jabber/jabber.h
@@ -27,7 +27,6 @@
 #include <glib.h>
 
 #include "bitlbee.h"
-#include "md5.h"
 #include "xmltree.h"
 
 extern GSList *jabber_connections;
@@ -104,7 +103,7 @@ struct jabber_data {
 	guint64 gmail_time;
 	char *gmail_tid;
 
-	md5_state_t cached_id_prefix;
+	GChecksum *cached_id_prefix;
 	GHashTable *node_cache;
 	GHashTable *buddies;
 

--- a/unix.c
+++ b/unix.c
@@ -260,15 +260,17 @@ static int crypt_main(int argc, char *argv[])
 		g_free(pass_cr);
 		g_free(pass_cl);
 	} else if (strcmp(argv[2], "hash") == 0) {
-		md5_byte_t pass_md5[21];
-		md5_state_t md5_state;
+		guint8 pass_md5[21];
+		GChecksum *md5_state;
+		gsize digest_len = MD5_HASH_SIZE;
 		char *encoded;
 
 		random_bytes(pass_md5 + 16, 5);
-		md5_init(&md5_state);
-		md5_append(&md5_state, (md5_byte_t *) argv[3], strlen(argv[3]));
-		md5_append(&md5_state, pass_md5 + 16, 5);   /* Add the salt. */
-		md5_finish(&md5_state, pass_md5);
+		md5_state = g_checksum_new(G_CHECKSUM_MD5);
+		g_checksum_update(md5_state, (guint8 *) argv[3], strlen(argv[3]));
+		g_checksum_update(md5_state, pass_md5 + 16, 5);   /* Add the salt. */
+		g_checksum_get_digest(md5_state, pass_md5, &digest_len);
+		g_checksum_free(md5_state);
 
 		encoded = base64_encode(pass_md5, 21);
 		printf("%s\n", encoded);


### PR DESCRIPTION
Migrate internal users of md5.h to using GChecksum directly.

Mark md5.h functions as deprecated, to encourage users to migrate to
alternatives. This seems useful even if we don't have concrete plans to
remove md5.h at this point.
