### PR TITLE
Deprecate sha1_* functions

### DIFF
--- a/lib/sha1.c
+++ b/lib/sha1.c
@@ -99,8 +99,11 @@ char *sha1_random_uuid(sha1_state_t * context)
 	guint8 dig[SHA1_HASH_SIZE];
 	char *ret = g_new0(char, 40);   /* 36 chars + \0 */
 	int i, p;
+	gsize digest_len = SHA1_HASH_SIZE;
 
-	sha1_finish(context, dig);
+	g_checksum_get_digest(*context, dig, &digest_len);
+	g_checksum_free(*context);
+
 	for (p = i = 0; i < 16; i++) {
 		if (i == 4 || i == 6 || i == 8 || i == 10) {
 			ret[p++] = '-';

--- a/lib/sha1.h
+++ b/lib/sha1.h
@@ -5,14 +5,20 @@
 #include <glib.h>
 #include <gmodule.h>
 
+#ifdef __GNUC__
+#define __SHA1_NON_PUBLIC_DEPRECATION__ __attribute__((deprecated("sha1.h will be removed from Bitlbee's public API. Please use another library (such as GLib's gchecksum) instead")))
+#else
+#define __SHA1_NON_PUBLIC_DEPRECATION__
+#endif
+
 #define SHA1_HASH_SIZE 20
 
 typedef GChecksum *sha1_state_t;
 
-void sha1_init(sha1_state_t *);
-void sha1_append(sha1_state_t *, const guint8 *, unsigned int);
-void sha1_finish(sha1_state_t *, guint8 digest[SHA1_HASH_SIZE]);
-void sha1_hmac(const char *, size_t, const char *, size_t, guint8 digest[SHA1_HASH_SIZE]);
+void sha1_init(sha1_state_t *) __SHA1_NON_PUBLIC_DEPRECATION__;
+void sha1_append(sha1_state_t *, const guint8 *, unsigned int) __SHA1_NON_PUBLIC_DEPRECATION__;
+void sha1_finish(sha1_state_t *, guint8 digest[SHA1_HASH_SIZE]) __SHA1_NON_PUBLIC_DEPRECATION__;
+void sha1_hmac(const char *, size_t, const char *, size_t, guint8 digest[SHA1_HASH_SIZE]) ;
 char *sha1_random_uuid(sha1_state_t *);
 
 #endif

--- a/protocols/jabber/conference.c
+++ b/protocols/jabber/conference.c
@@ -22,7 +22,6 @@
 \***************************************************************************/
 
 #include "jabber.h"
-#include "sha1.h"
 
 static xt_status jabber_chat_join_failed(struct im_connection *ic, struct xt_node *node, struct xt_node *orig);
 static xt_status jabber_chat_self_message(struct im_connection *ic, struct xt_node *node, struct xt_node *orig);
@@ -78,15 +77,15 @@ struct groupchat *jabber_chat_with(struct im_connection *ic, char *who)
 	struct jabber_data *jd = ic->proto_data;
 	struct jabber_chat *jc;
 	struct groupchat *c;
-	sha1_state_t sum;
+	GChecksum *sum;
 	double now = gettime();
 	char *uuid, *rjid, *cserv;
 
-	sha1_init(&sum);
-	sha1_append(&sum, (uint8_t *) ic->acc->user, strlen(ic->acc->user));
-	sha1_append(&sum, (uint8_t *) &now, sizeof(now));
-	sha1_append(&sum, (uint8_t *) who, strlen(who));
-	uuid = sha1_random_uuid(&sum);
+	sum = g_checksum_new(G_CHECKSUM_SHA1);
+	g_checksum_update(sum, (uint8_t *) ic->acc->user, strlen(ic->acc->user));
+	g_checksum_update(sum, (uint8_t *) &now, sizeof(now));
+	g_checksum_update(sum, (uint8_t *) who, strlen(who));
+	uuid = sha1_random_uuid(sum);
 
 	if (jd->flags & JFLAG_GTALK) {
 		cserv = g_strdup("groupchat.google.com");

--- a/protocols/jabber/si.c
+++ b/protocols/jabber/si.c
@@ -22,7 +22,6 @@
 \***************************************************************************/
 
 #include "jabber.h"
-#include "sha1.h"
 
 void jabber_si_answer_request(file_transfer_t *ft);
 int jabber_si_send_request(struct im_connection *ic, char *who, struct jabber_transfer *tf);


### PR DESCRIPTION
* Migrate existing callers in bitlbee to directly use GChecksum
* Mark functions as deprecated for external users