### PR TITLE
Improve control over automatic properties of Systemd configuration

### DIFF
--- a/configure
+++ b/configure
@@ -776,8 +776,12 @@ if [ "$systemd" = "1" ]; then
 	if [ -z "$sysusersdir" ] ; then
 		sysusersdir=$(pkgconf_systemd_var sysusersdir sysusers_dir)
 	fi
+fi
 
+if [ -n "$systemdsystemunitdir" ]; then
 	echo "SYSTEMDSYSTEMUNITDIR=$systemdsystemunitdir" >> Makefile.settings
+fi
+if [ -n "$sysusersdir" ]; then
 	echo "SYSUSERSDIR=$sysusersdir" >> Makefile.settings
 fi
 

--- a/configure
+++ b/configure
@@ -159,7 +159,8 @@ Option		Description				Default
 --ssl=...	SSL library to use (gnutls, nss, openssl, auto)
 							$ssl
 --external_json_parser=0/1/auto	Use External JSON parser $external_json_parser
---systemd=0/1  Enable/disable systemd support $systemd
+--systemd=0/1	Enable/disable automatic detection
+		of systemd directories			$systemd
 
 
 --target=...	Cross compilation target 		same as host
@@ -1031,9 +1032,9 @@ else
 fi
 
 if [ "$systemd" = "1" ]; then
-	echo '  systemd enabled.'
+	echo '  systemd autodetection enabled.'
 else
-	echo '  systemd disabled.'
+	echo '  systemd autodetection disabled.'
 fi
 
 echo '  Using python: '$PYTHON

--- a/configure
+++ b/configure
@@ -772,12 +772,12 @@ if [ "$systemd" = "1" ]; then
 	if [ -z "$systemdsystemunitdir" ]; then
 		systemdsystemunitdir=$(pkgconf_systemd_var systemdsystemunitdir systemd_system_unit_dir)
 	fi
-    if [ -z "$sysusersdir" ] ; then
-        sysusersdir=$(pkgconf_systemd_var sysusersdir sysusers_dir)
-    fi
+	if [ -z "$sysusersdir" ] ; then
+		sysusersdir=$(pkgconf_systemd_var sysusersdir sysusers_dir)
+	fi
 
 	echo "SYSTEMDSYSTEMUNITDIR=$systemdsystemunitdir" >> Makefile.settings
-    echo "SYSUSERSDIR=$sysusersdir" >> Makefile.settings
+	echo "SYSUSERSDIR=$sysusersdir" >> Makefile.settings
 fi
 
 if [ "$gcov" = "1" ]; then

--- a/configure
+++ b/configure
@@ -130,7 +130,7 @@ Option		Description				Default
 --datadir=...						$datadir
 --plugindir=...						$plugindir
 --systemdsystemunitdir=...				$systemdsystemunitdir
---sysusersdir                       $sysusersdir
+--sysusersdir=...					$sysusersdir
 --pidfile=...						$pidfile
 --config=...						$config
 


### PR DESCRIPTION
PR #163 introduced changes which would make the Gentoo package unnecessarily more complicated.

We don't use `sysusersdir` because we have different mechanism for user and group management and there is no need to force users to install `bitlbee.sysusers` file. And we are setting `--systemdsystemunitdir` in configuration phase to some concrete path. This makes the buildtime dependency on `$PKG_CONFIG systemd` unnecessary for us.

In this PR I propose to give packagers more control over systemd configuration. With this change we will be able to use
```
configure --systemd=0 --systemdsystemunitdir=/our/path
```
to fulfill our needs without introduction of new conditional dependency on systemd.

I have also unified indentation and improved description of `--systemd` option which controls only autodetection.