### PR TITLE
Migrate badge/shield from Travis to GitHub Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![](https://www.bitlbee.org/style/logo.png)
 
-[![Build Status](https://travis-ci.org/bitlbee/bitlbee.svg)](https://travis-ci.org/bitlbee/bitlbee)
+[![Tests](https://github.com/bitlbee/bitlbee/actions/workflows/test.yaml/badge.svg)](https://github.com/bitlbee/bitlbee/actions/workflows/test.yaml)
 [![Coverity Scan Build Status](https://scan.coverity.com/projects/4028/badge.svg)](https://scan.coverity.com/projects/4028)
 
 An IRC to other chat networks gateway


### PR DESCRIPTION
Synchronize badge/shield in `README.md` with commit 294b98d8bf132de4bf17237b48ec45f9d612dcb3.