### PR TITLE
Simplify g_memdup2() usage

### DIFF
--- a/lib/json_util.c
+++ b/lib/json_util.c
@@ -28,9 +28,7 @@
 #include "json_util.h"
 
 /* g_memdup() deprecated as of glib 2.68.0 */
-#ifdef GLIB_VERSION_2_68
-#define g_memdup2 g_memdup2
-#else
+#ifndef GLIB_VERSION_2_68
 #define g_memdup2 g_memdup
 #endif
 

--- a/lib/xmltree.c
+++ b/lib/xmltree.c
@@ -33,9 +33,7 @@
 #define g_strncasecmp g_ascii_strncasecmp
 
 /* g_memdup() deprecated as of glib 2.68.0 */
-#ifdef GLIB_VERSION_2_68
-#define g_memdup2 g_memdup2
-#else
+#ifndef GLIB_VERSION_2_68
 #define g_memdup2 g_memdup
 #endif
 


### PR DESCRIPTION
Apply partial attempt from commit 79331ba2a53e55e4d4397713dc33df0ddba907b1 in general.