### PR TITLE
Switch from 'which' to 'command -v' to increase portability

### DIFF
--- a/configure
+++ b/configure
@@ -833,7 +833,7 @@ fi
 
 if [ -z "$PYTHON" ]; then
 	for pp in python python3 python2; do
-		if which $pp > /dev/null; then
+		if command -v $pp > /dev/null; then
 			PYTHON=$pp
 			break
 		fi


### PR DESCRIPTION
In minimal buildroots `which` might not be installed, while `command -v` is a shell built-in in all POSIX 2008 compliant shells, supported by at least ash, bash, busybox, dash, ksh, mksh and zsh.