### PR TITLE
jabber: fix regression with gchecksum in jabber_cache_add

### DIFF
--- a/protocols/jabber/jabber_util.c
+++ b/protocols/jabber/jabber_util.c
@@ -139,7 +139,7 @@ void jabber_cache_add(struct im_connection *ic, struct xt_node *node, jabber_cac
 {
 	struct jabber_data *jd = ic->proto_data;
 	struct jabber_cache_entry *entry = g_new0(struct jabber_cache_entry, 1);
-	GChecksum *id_hash;
+	GChecksum *id_hash, *copy;
 	gsize digest_len = MD5_HASH_SIZE;
 	guint8 id_sum[MD5_HASH_SIZE];
 	char *id, *asc_hash;
@@ -148,8 +148,10 @@ void jabber_cache_add(struct im_connection *ic, struct xt_node *node, jabber_cac
 
 	id_hash = jd->cached_id_prefix;
 	g_checksum_update(id_hash, (guint8 *) &next_id, sizeof(next_id));
-	g_checksum_get_digest(id_hash, id_sum, &digest_len);
-	g_checksum_free(id_hash);
+
+	copy = g_checksum_copy(id_hash);
+	g_checksum_get_digest(copy, id_sum, &digest_len);
+	g_checksum_free(copy);
 
 	asc_hash = base64_encode(id_sum, 12);
 


### PR DESCRIPTION
This crashed with "The checksum '%s' has been closed and cannot be updated anymore." (which is also a user after free)

Issue introduced in 1bdc6696aefb617873b56001f81d649d6ca3aa8e which is not in any released version.

There was this md5_digest_keep() function that freed a copy of the checksum instead of the one you pass. The code that it was replaced with ignored this distinction, and since jabber_cache_add() needs to reuse the GChecksum this led to this issue.

No other place in the bitlbee code used this function.