### PR TITLE
Rename /OPER command /oper everywhere

### DIFF
--- a/bitlbee.h
+++ b/bitlbee.h
@@ -132,7 +132,7 @@ extern "C" {
 #define CONF_FILE_DEF ETCDIR "bitlbee.conf"
 
 /* Hack to give a little bit more password security on IRC: If an account has
-   this password set, use /OPER to change it. */
+   this password set, use /oper to change it. */
 #define PASSWORD_PENDING "\r\rchangeme\r\r"
 
 #include "bee.h"

--- a/doc/user-guide/commands.xml
+++ b/doc/user-guide/commands.xml
@@ -24,7 +24,7 @@
 				</para>
 
 				<para>
-					You can omit the password and enter it separately using the IRC /OPER command. This lets you enter your password without your IRC client echoing it on screen or recording it in logs.
+					You can omit the password and enter it separately using the IRC /oper command. This lets you enter your password without your IRC client echoing it on screen or recording it in logs.
 				</para>
 			</description>
 			
@@ -1835,7 +1835,7 @@
 			</para>
 
 			<para>
-				You can omit the password and enter it separately using the IRC /OPER command. This lets you enter your password without your IRC client echoing it on screen or recording it in logs.
+				You can omit the password and enter it separately using the IRC /oper command. This lets you enter your password without your IRC client echoing it on screen or recording it in logs.
 			</para>
 		</description>
 
@@ -1863,7 +1863,7 @@
 			</para>
 
 			<para>
-				You can omit the password and enter it separately using the IRC /OPER command. This lets you enter your password without your IRC client echoing it on screen or recording it in logs.
+				You can omit the password and enter it separately using the IRC /oper command. This lets you enter your password without your IRC client echoing it on screen or recording it in logs.
 			</para>
 		</description>
 	</bitlbee-command>

--- a/irc.h
+++ b/irc.h
@@ -57,7 +57,7 @@ typedef enum {
 	/* Not really status stuff, but other kinds of flags: For slightly
 	   better password security, since the only way to send passwords
 	   to the IRC server securely (i.e. not echoing to screen or written
-	   to logfiles) is the /OPER command, try to use that command for
+	   to logfiles) is the /oper command, try to use that command for
 	   stuff that matters. */
 	OPER_HACK_IDENTIFY = 0x100,
 	OPER_HACK_IDENTIFY_NOLOAD = 0x01100,

--- a/irc_commands.c
+++ b/irc_commands.c
@@ -560,7 +560,7 @@ static void irc_cmd_oper_hack(irc_t *irc, char **cmd)
 {
 	char *password = g_strjoinv(" ", cmd + 2);
 
-	/* /OPER can now also be used to enter IM/identify passwords without
+	/* /oper can now also be used to enter IM/identify passwords without
 	   echoing. It's a hack but the extra password security is worth it. */
 	if (irc->status & OPER_HACK_ACCOUNT_PASSWORD) {
 		account_t *a;

--- a/protocols/account.c
+++ b/protocols/account.c
@@ -156,7 +156,7 @@ char *set_eval_account(set_t *set, char *value)
 			} else {
 				value = PASSWORD_PENDING;
 				((irc_t *) acc->bee->ui_data)->status |= OPER_HACK_ACCOUNT_PASSWORD;
-				irc_rootmsg((irc_t *) acc->bee->ui_data, "You may now use /OPER to set the password");
+				irc_rootmsg((irc_t *) acc->bee->ui_data, "You may now use /oper to set the password");
 			}
 		}
 

--- a/root_commands.c
+++ b/root_commands.c
@@ -137,7 +137,7 @@ static void cmd_identify(irc_t *irc, char **cmd)
 	}
 
 	if (password == NULL) {
-		irc_rootmsg(irc, "About to identify, use /OPER to enter the password");
+		irc_rootmsg(irc, "About to identify, use /oper to enter the password");
 		irc->status |= OPER_HACK_IDENTIFY;
 		return;
 	}
@@ -226,7 +226,7 @@ static void cmd_register(irc_t *irc, char **cmd)
 	}
 
 	if (cmd[1] == NULL) {
-		irc_rootmsg(irc, "About to register, use /OPER to enter the password");
+		irc_rootmsg(irc, "About to register, use /oper to enter the password");
 		irc->status |= OPER_HACK_REGISTER;
 		return;
 	}
@@ -427,7 +427,7 @@ static void cmd_account(irc_t *irc, char **cmd)
 			for (a = irc->b->accounts; a; a = a->next) {
 				if (strcmp(a->pass, PASSWORD_PENDING) == 0) {
 					irc_rootmsg(irc, "Enter password for account %s "
-					            "first (use /OPER)", a->tag);
+					            "first (use /oper)", a->tag);
 					return;
 				}
 			}
@@ -473,10 +473,10 @@ static void cmd_account(irc_t *irc, char **cmd)
 			} else if (prpl->options & PRPL_OPT_PASSWORD_OPTIONAL) {
 				*a->pass = '\0';
 				irc_rootmsg(irc, "Passwords are optional for this account. "
-				            "If you wish to enter the password with /OPER, do "
+				            "If you wish to enter the password with /oper, do "
 				            "account %s set -del password", a->tag);
 			} else {
-				irc_rootmsg(irc, "You can now use the /OPER command to "
+				irc_rootmsg(irc, "You can now use the /oper command to "
 				            "enter the password");
 				if (oauth) {
 					irc_rootmsg(irc, "Alternatively, enable OAuth if "
@@ -533,7 +533,7 @@ static void cmd_account(irc_t *irc, char **cmd)
 				if (!a->ic && a->auto_connect && a->prpl != &protocol_missing) {
 					if (strcmp(a->pass, PASSWORD_PENDING) == 0) {
 						irc_rootmsg(irc, "Enter password for account %s "
-						            "first (use /OPER)", a->tag);
+						            "first (use /oper)", a->tag);
 					} else {
 						account_on(irc->b, a);
 					}
@@ -589,7 +589,7 @@ static void cmd_account(irc_t *irc, char **cmd)
 			irc_rootmsg(irc, "Account already online");
 		} else if (strcmp(a->pass, PASSWORD_PENDING) == 0) {
 			irc_rootmsg(irc, "Enter password for account %s "
-			            "first (use /OPER)", a->tag);
+			            "first (use /oper)", a->tag);
 		} else if (a->prpl == &protocol_missing) {
 			char *proto = set_getstr(&a->set, "_protocol_name");
 			char *msg = explain_unknown_protocol(proto);


### PR DESCRIPTION
Weechat is in the process of making its identifiers case-sensitive (see https://specs.weechat.org/specs/2023-001-case-sensitive-identifiers.html#changes). As a result, /OPER is no longer a valid weechat command.

This patch is an example patch to address this issue, replacing all /OPER references to /oper.

I don't know if this affects other IRC clients and if there is a standard favoring /OPER or /oper.

It's an example patch, you may want to replace the message with e.g. "use /oper or /OPER in older weechat versions".