### PR TITLE
Bump GitHub actions/checkout from 3 to 4

### DIFF
--- a/.github/workflows/coverity.yaml
+++ b/.github/workflows/coverity.yaml
@@ -13,7 +13,7 @@ jobs:
   coverity:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install dependencies
       run: |
        sudo apt-get update && sudo apt-get -y install \

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,14 +13,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Run ShellCheck
       uses: ludeeus/action-shellcheck@master
   tests:
     needs: shellcheck
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install dependencies
       run: |
        sudo apt-get update && sudo apt-get -y install \


### PR DESCRIPTION
Main change is an update of the default runtime to Node 20 inside the action.