### PR TITLE
Adjust sha1_random_uuid usage in jabber/conference.c

### DIFF
--- a/protocols/jabber/conference.c
+++ b/protocols/jabber/conference.c
@@ -22,6 +22,7 @@
 \***************************************************************************/
 
 #include "jabber.h"
+#include "sha1.h"
 
 static xt_status jabber_chat_join_failed(struct im_connection *ic, struct xt_node *node, struct xt_node *orig);
 static xt_status jabber_chat_self_message(struct im_connection *ic, struct xt_node *node, struct xt_node *orig);
@@ -85,7 +86,7 @@ struct groupchat *jabber_chat_with(struct im_connection *ic, char *who)
 	g_checksum_update(sum, (uint8_t *) ic->acc->user, strlen(ic->acc->user));
 	g_checksum_update(sum, (uint8_t *) &now, sizeof(now));
 	g_checksum_update(sum, (uint8_t *) who, strlen(who));
-	uuid = sha1_random_uuid(sum);
+	uuid = sha1_random_uuid(&sum);
 
 	if (jd->flags & JFLAG_GTALK) {
 		cserv = g_strdup("groupchat.google.com");


### PR DESCRIPTION
The `jabber/conference.c` module failed to compile due to the implicit use of the `sha1_random_uuid` function following the deprecation of the sha1 lib. This patch reintroduces the `sha1.h` include to resolve compilation errors encountered with GCC 14:
```
  error: implicit declaration of function ‘sha1_random_uuid’
```
Additionally, the patch corrects the type mismatch error when calling `sha1_random_uuid`, aligning with the expected `GChecksum **` type, otherwise compilation fails with following error:
```
  error: passing argument 1 of ‘sha1_random_uuid’ from incompatible pointer type
  note: expected ‘GChecksum **’ {aka ‘struct _GChecksum **’} but argument is of type ‘GChecksum *’ {aka ‘struct _GChecksum *’}
```
Fixes: a4ac9c413b97 ("Deprecate sha1_* functions (#172)")