### PR TITLE
Use unsigned integer for DCC IP addr

### DIFF
--- a/dcc.c
+++ b/dcc.c
@@ -191,7 +191,7 @@ int dccs_send_request(struct dcc_file_transfer *df, irc_user_t *iu, struct socka
 	if (saddr->ss_family == AF_INET) {
 		struct sockaddr_in *saddr_ipv4 = ( struct sockaddr_in *) saddr;
 
-		sprintf(ipaddr, "%d",
+		sprintf(ipaddr, "%u",
 		        ntohl(saddr_ipv4->sin_addr.s_addr));
 		port = saddr_ipv4->sin_port;
 	} else {


### PR DESCRIPTION
DCC send should use a [positive integer for the IP addr](https://modern.ircdocs.horse/dcc.html#dcc-query-syntax), the ipaddr field was being formatted with "%d" instead of "%u", meaning "large" IP addresses would come through as negative.