### PR TITLE
Doc: Default IRC assumption is now libera

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,4 +51,4 @@ Once you have the dependencies, building should be a matter of:
 
 ## Help?
 
-Join **#BitlBee** on OFTC (**irc.oftc.net**) (OFTC, *not* freenode!)
+Join **#BitlBee** on OFTC (**irc.oftc.net**) (OFTC, *not* libera!)

--- a/doc/user-guide/help.xml
+++ b/doc/user-guide/help.xml
@@ -29,7 +29,7 @@ Some more help can be found on <ulink link="https://wiki.bitlbee.org/">https://w
 </para>
 
 <para>
-For other things than bug reports, you can join <emphasis>#BitlBee</emphasis> on OFTC (<emphasis>irc.oftc.net</emphasis>) (OFTC, *not* freenode!) and flame us right in the face. :-)
+For other things than bug reports, you can join <emphasis>#BitlBee</emphasis> on OFTC (<emphasis>irc.oftc.net</emphasis>) (OFTC, *not* libera!) and flame us right in the face. :-)
 </para>
 
 </preface>


### PR DESCRIPTION
Freenode doesn't even make the top 10 networks on netsplit.de anymore, and hasn't for years.

At least, to the extent IRC is still well known enough to have default assumptions. Bit of a blast from the past seeing this in help text. :)