### PR TITLE
purple: hack to get the purple-googlechat working

### DIFF
--- a/protocols/purple/purple.c
+++ b/protocols/purple/purple.c
@@ -114,6 +114,7 @@ static gboolean purple_account_should_set_nick(account_t *acc)
 	 */
 	char *whitelist[] = {
 		"prpl-hangouts",
+		"prpl-googlechat",
 		"prpl-eionrobb-funyahoo-plusplus",
 		"prpl-line",
 		NULL,


### PR DESCRIPTION
this hack automatically resolves user IDs into full names.
https://github.com/EionRobb/purple-googlechat/issues/70